### PR TITLE
2nd DB9 port for the NanoMig connected by the spare pins

### DIFF
--- a/src/tang/nano20k/nanomig.cst
+++ b/src/tang/nano20k/nanomig.cst
@@ -55,7 +55,7 @@ IO_PORT "sd_dat[2]" PULL_MODE=NONE IO_TYPE=LVCMOS33;
 IO_LOC "sd_dat[3]" 81;
 IO_PORT "sd_dat[3]" PULL_MODE=NONE IO_TYPE=LVCMOS33;
 
-// generic IO pins to use for e.g. db9 mouse or joystick
+// generic IO pins used for DB9 port 1 (mouse & joystick)
 IO_LOC "io[0]" 27;
 IO_PORT "io[0]" PULL_MODE=UP IO_TYPE=LVCMOS33;
 IO_LOC "io[1]" 28;
@@ -68,10 +68,18 @@ IO_LOC "io[4]" 29;
 IO_PORT "io[4]" PULL_MODE=UP IO_TYPE=LVCMOS33;
 IO_LOC "io[5]" 30;
 IO_PORT "io[5]" PULL_MODE=UP IO_TYPE=LVCMOS33;
-IO_LOC "io[6]" 31;
-IO_PORT "io[6]" PULL_MODE=UP IO_TYPE=LVCMOS33;
-IO_LOC "io[7]" 77;
-IO_PORT "io[7]" PULL_MODE=UP IO_TYPE=LVCMOS33;
+
+// spare IO pins used for 2nd DB9 port
+IO_LOC "spare[0]" 73;
+IO_PORT "spare[0]" PULL_MODE=UP IO_TYPE=LVCMOS33;
+IO_LOC "spare[1]" 74;
+IO_PORT "spare[1]" PULL_MODE=UP IO_TYPE=LVCMOS33;
+IO_LOC "spare[2]" 77;
+IO_PORT "spare[2]" PULL_MODE=UP IO_TYPE=LVCMOS33;
+IO_LOC "spare[3]" 31;
+IO_PORT "spare[3]" PULL_MODE=UP IO_TYPE=LVCMOS33;
+IO_LOC "spare[4]" 49;
+IO_PORT "spare[4]" PULL_MODE=UP IO_TYPE=LVCMOS33;
 
 // connection to the external BL616/M0S
 IO_LOC "m0s[0]" 42;

--- a/src/tang/nano20k/top.sv
+++ b/src/tang/nano20k/top.sv
@@ -38,8 +38,11 @@ module top(
   output [1:0]	O_sdram_ba, // two banks
   output [3:0]	O_sdram_dqm, // 32/4
 
-  // generic IO, used for mouse/joystick/...
-  input [7:0]	io,
+  // generic IO, used for mouse & joystick
+  input [5:0]	io,
+
+  // spare IO, used for 2nd joystick
+  input [4:0]   spare,
 
   // interface to external BL616/M0S
   inout [5:0]	m0s,
@@ -67,8 +70,11 @@ module top(
   output [2:0]	tmds_d_p
 );
 
-// physcial dsub9 joystick  
+// physcial dsub9 joystick & mouse port 1 
 wire [5:0] db9_joy = { !io[5], !io[0], !io[2], !io[1], !io[4], !io[3] };   
+
+// physcial dsub9 joystick port 2  
+wire [4:0] db9_joy2 = { !spare[0], !spare[2], !spare[1], !spare[4], !spare[3] }; 
    
 wire [5:0]	leds;
 assign leds[5] = 1'b0;
@@ -343,8 +349,8 @@ osd_u8g2 osd_u8g2 (
 wire [14:0] audio_left;
 wire [14:0] audio_right;   
 
-// map first HID/USB joystick into second amiga joystick port
-// wire in db9 joystick
+// map first HID/USB joystick into first amiga joystick port
+// wire in db9 joystick & mouse
 wire [7:0] joystick1 = { 
 	   hid_joy0[7], 
 	   hid_joy0[6], 
@@ -355,8 +361,18 @@ wire [7:0] joystick1 = {
 	  (hid_joy0[1] | db9_joy[1]),
 	  (hid_joy0[0] | db9_joy[0]) };   
 
-wire [7:0] joystick0 = hid_joy1;
-   
+// map second HID/USB joystick into second amiga joystick port
+// wire in db9 joystick   
+wire [7:0] joystick0 = { 
+       hid_joy1[7], 
+       hid_joy1[6], 
+       hid_joy1[5], 
+      (hid_joy1[4] | db9_joy2[4]),
+      (hid_joy1[3] | db9_joy2[3]), 
+      (hid_joy1[2] | db9_joy2[2]),
+      (hid_joy1[1] | db9_joy2[1]),
+      (hid_joy1[0] | db9_joy2[0]) }; 
+
 wire [23:1] cpu_a;
 wire cpu_as_n, cpu_lds_n, cpu_uds_n;
 wire cpu_rw, cpu_dtack_n;


### PR DESCRIPTION
The default DB9 port of the NanoMig supports Mice (two buttons) & Joysticks (Amiga Joystick Port 1)
The goal of this commit was to connect a 2nd DB9 port to the Nanomig (Amiga Joystick Port 2). As only 5 spare IO pins are available, only one-button joysticks are supported. This should be no problem as almost all Amiga games expect only one fire button.

![477939240-33c07ded-53fd-4a25-b0f3-8c9ec055f65f](https://github.com/user-attachments/assets/768a4313-fb49-4d3d-bd99-4a5e55024bc1)
