### PR TITLE
Fix three hdmi audio defects, on every board

### DIFF
--- a/src/gatemate/evb/top.sv
+++ b/src/gatemate/evb/top.sv
@@ -896,16 +896,25 @@ reg signed [14:0] scaled_audio_left;
 reg signed [14:0] scaled_audio_right;
 
 // generate 48khz audio clock
-reg clk_audio;
-reg [8:0] aclk_cnt;
+// An integer divider cannot land on 48kHz, and the truncation leaves the
+// stream running fast, so sinks drop a chunk of audio every few seconds. A
+// phase accumulator keeps the fractional part.
+localparam [31:0] AUDIO_INC = (64'd48000 <<< 32) / `PIXEL_CLOCK;
+reg [31:0] aclk_acc;
+reg        clk_audio;
+reg        aclk_tick;
 
 always @(posedge clk_pixel) begin
-    // divisor = pixel clock / 48000 / 2 - 1
-    if(aclk_cnt < `PIXEL_CLOCK / 48000 / 2 -1)
-      aclk_cnt <= aclk_cnt + 9'd1;
-    else begin
-       aclk_cnt <= 9'd0;
-       clk_audio <= ~clk_audio;
+    aclk_acc  <= aclk_acc + AUDIO_INC;
+    clk_audio <= aclk_acc[31];                 // msb of the accumulator = 48kHz
+    aclk_tick <= (clk_audio != aclk_acc[31]);  // high the cycle after each edge
+
+    // The sample word must not change on the same clk_pixel edge that toggles
+    // clk_audio: the hdmi module latches it on that very edge, so data and
+    // clock would race and the captured word could pick up wrong bits, which
+    // is audible as noisy samples. Updating one cycle later leaves the word
+    // stable for a full audio half period before it is sampled.
+    if(aclk_tick) begin
 
         // --- Stereo Mix (75/25)-------------------------------------------
         // 16-bit signed wires prevent any overflow; the result
@@ -957,8 +966,8 @@ always @(posedge clk_pixel) begin
         // Convert signed two's complement → offset binary:
         // flip sign bit (bit 14).  Bit 15 = 0 (15-bit audio in 16-bit slot).
         // Explicit per-element assignment avoids unpacked-array ambiguity.
-        audio_reg[0] <= {1'b0, ~scaled_audio_left[14],  scaled_audio_left[13:0]};
-        audio_reg[1] <= {1'b0, ~scaled_audio_right[14], scaled_audio_right[13:0]};	
+        audio_reg[0] <= {scaled_audio_left[14], scaled_audio_left[14:0]};
+        audio_reg[1] <= {scaled_audio_right[14], scaled_audio_right[14:0]};	
 
     end
 end

--- a/src/lattice/icepi-zero/top.sv
+++ b/src/lattice/icepi-zero/top.sv
@@ -920,16 +920,25 @@ reg signed [14:0] scaled_audio_left;
 reg signed [14:0] scaled_audio_right;
 
 // generate 48khz audio clock
-reg clk_audio;
-reg [8:0] aclk_cnt;
+// An integer divider cannot land on 48kHz, and the truncation leaves the
+// stream running fast, so sinks drop a chunk of audio every few seconds. A
+// phase accumulator keeps the fractional part.
+localparam [31:0] AUDIO_INC = (64'd48000 <<< 32) / `PIXEL_CLOCK;
+reg [31:0] aclk_acc;
+reg        clk_audio;
+reg        aclk_tick;
 
 always @(posedge clk_pixel) begin
-    // divisor = pixel clock / 48000 / 2 - 1
-    if(aclk_cnt < `PIXEL_CLOCK / 48000 / 2 -1)
-      aclk_cnt <= aclk_cnt + 9'd1;
-    else begin
-       aclk_cnt <= 9'd0;
-       clk_audio <= ~clk_audio;
+    aclk_acc  <= aclk_acc + AUDIO_INC;
+    clk_audio <= aclk_acc[31];                 // msb of the accumulator = 48kHz
+    aclk_tick <= (clk_audio != aclk_acc[31]);  // high the cycle after each edge
+
+    // The sample word must not change on the same clk_pixel edge that toggles
+    // clk_audio: the hdmi module latches it on that very edge, so data and
+    // clock would race and the captured word could pick up wrong bits, which
+    // is audible as noisy samples. Updating one cycle later leaves the word
+    // stable for a full audio half period before it is sampled.
+    if(aclk_tick) begin
 
         // --- Stereo Mix (75/25)-------------------------------------------
         // 16-bit signed wires prevent any overflow; the result
@@ -981,8 +990,8 @@ always @(posedge clk_pixel) begin
         // Convert signed two's complement → offset binary:
         // flip sign bit (bit 14).  Bit 15 = 0 (15-bit audio in 16-bit slot).
         // Explicit per-element assignment avoids unpacked-array ambiguity.
-        audio_reg[0] <= {1'b0, ~scaled_audio_left[14],  scaled_audio_left[13:0]};
-        audio_reg[1] <= {1'b0, ~scaled_audio_right[14], scaled_audio_right[13:0]};
+        audio_reg[0] <= {scaled_audio_left[14], scaled_audio_left[14:0]};
+        audio_reg[1] <= {scaled_audio_right[14], scaled_audio_right[14:0]};
 
     end
 end

--- a/src/mistle/gw3a_20/top.sv
+++ b/src/mistle/gw3a_20/top.sv
@@ -745,15 +745,25 @@ reg [14:0] scaled_audio_left;
 reg [14:0] scaled_audio_right;
 
 // generate 48khz audio clock
-reg clk_audio;
-reg [8:0] aclk_cnt;
+// An integer divider cannot land on 48kHz, and the truncation leaves the
+// stream running fast, so sinks drop a chunk of audio every few seconds. A
+// phase accumulator keeps the fractional part.
+localparam [31:0] AUDIO_INC = (64'd48000 <<< 32) / `PIXEL_CLOCK;
+reg [31:0] aclk_acc;
+reg        clk_audio;
+reg        aclk_tick;
+
 always @(posedge clk_pixel) begin
-    // divisor = pixel clock / 48000 / 2 - 1
-    if(aclk_cnt < `PIXEL_CLOCK / 48000 / 2 -1)
-      aclk_cnt <= aclk_cnt + 9'd1;
-    else begin
-       aclk_cnt <= 9'd0;
-       clk_audio <= ~clk_audio;
+    aclk_acc  <= aclk_acc + AUDIO_INC;
+    clk_audio <= aclk_acc[31];                 // msb of the accumulator = 48kHz
+    aclk_tick <= (clk_audio != aclk_acc[31]);  // high the cycle after each edge
+
+    // The sample word must not change on the same clk_pixel edge that toggles
+    // clk_audio: the hdmi module latches it on that very edge, so data and
+    // clock would race and the captured word could pick up wrong bits, which
+    // is audible as noisy samples. Updating one cycle later leaves the word
+    // stable for a full audio half period before it is sampled.
+    if(aclk_tick) begin
 
         // --- Stereo Mix (75/25)-------------------------------------------
         // 16-bit signed wires prevent any overflow; the result
@@ -799,7 +809,7 @@ always @(posedge clk_pixel) begin
             end
         endcase
 
-	   audio_reg <= { { 1'b0, ~scaled_audio_left[14],scaled_audio_left[13:0]}, {1'b0, ~scaled_audio_right[14],scaled_audio_right[13:0]}};	
+	   audio_reg <= { {scaled_audio_left[14], scaled_audio_left[14:0]}, {scaled_audio_right[14], scaled_audio_right[14:0]}};	
 
     end
 end

--- a/src/mistle/gw5a_25/top.sv
+++ b/src/mistle/gw5a_25/top.sv
@@ -768,15 +768,25 @@ reg [14:0] scaled_audio_left;
 reg [14:0] scaled_audio_right;
 
 // generate 48khz audio clock
-reg clk_audio;
-reg [8:0] aclk_cnt;
+// An integer divider cannot land on 48kHz, and the truncation leaves the
+// stream running fast, so sinks drop a chunk of audio every few seconds. A
+// phase accumulator keeps the fractional part.
+localparam [31:0] AUDIO_INC = (64'd48000 <<< 32) / `PIXEL_CLOCK;
+reg [31:0] aclk_acc;
+reg        clk_audio;
+reg        aclk_tick;
+
 always @(posedge clk_pixel) begin
-    // divisor = pixel clock / 48000 / 2 - 1
-    if(aclk_cnt < `PIXEL_CLOCK / 48000 / 2 -1)
-      aclk_cnt <= aclk_cnt + 9'd1;
-    else begin
-       aclk_cnt <= 9'd0;
-       clk_audio <= ~clk_audio;
+    aclk_acc  <= aclk_acc + AUDIO_INC;
+    clk_audio <= aclk_acc[31];                 // msb of the accumulator = 48kHz
+    aclk_tick <= (clk_audio != aclk_acc[31]);  // high the cycle after each edge
+
+    // The sample word must not change on the same clk_pixel edge that toggles
+    // clk_audio: the hdmi module latches it on that very edge, so data and
+    // clock would race and the captured word could pick up wrong bits, which
+    // is audible as noisy samples. Updating one cycle later leaves the word
+    // stable for a full audio half period before it is sampled.
+    if(aclk_tick) begin
 
         // --- Stereo Mix (75/25)-------------------------------------------
         // 16-bit signed wires prevent any overflow; the result
@@ -822,7 +832,7 @@ always @(posedge clk_pixel) begin
             end
         endcase
 
-	   audio_reg <= { { 1'b0, ~scaled_audio_left[14],scaled_audio_left[13:0]}, {1'b0, ~scaled_audio_right[14],scaled_audio_right[13:0]}};	
+	   audio_reg <= { {scaled_audio_left[14], scaled_audio_left[14:0]}, {scaled_audio_right[14], scaled_audio_right[14:0]}};	
 
     end
 end

--- a/src/tang/console138k/top.sv
+++ b/src/tang/console138k/top.sv
@@ -895,16 +895,25 @@ reg signed [14:0] scaled_audio_left;
 reg signed [14:0] scaled_audio_right;
 
 // generate 48khz audio clock
-reg clk_audio;
-reg [8:0] aclk_cnt;
+// An integer divider cannot land on 48kHz, and the truncation leaves the
+// stream running fast, so sinks drop a chunk of audio every few seconds. A
+// phase accumulator keeps the fractional part.
+localparam [31:0] AUDIO_INC = (64'd48000 <<< 32) / `PIXEL_CLOCK;
+reg [31:0] aclk_acc;
+reg        clk_audio;
+reg        aclk_tick;
 
 always @(posedge clk_pixel) begin
-    // divisor = pixel clock / 48000 / 2 - 1
-    if(aclk_cnt < `PIXEL_CLOCK / 48000 / 2 -1)
-      aclk_cnt <= aclk_cnt + 9'd1;
-    else begin
-       aclk_cnt <= 9'd0;
-       clk_audio <= ~clk_audio;
+    aclk_acc  <= aclk_acc + AUDIO_INC;
+    clk_audio <= aclk_acc[31];                 // msb of the accumulator = 48kHz
+    aclk_tick <= (clk_audio != aclk_acc[31]);  // high the cycle after each edge
+
+    // The sample word must not change on the same clk_pixel edge that toggles
+    // clk_audio: the hdmi module latches it on that very edge, so data and
+    // clock would race and the captured word could pick up wrong bits, which
+    // is audible as noisy samples. Updating one cycle later leaves the word
+    // stable for a full audio half period before it is sampled.
+    if(aclk_tick) begin
 
         // --- Stereo Mix (75/25)-------------------------------------------
         // 16-bit signed wires prevent any overflow; the result
@@ -956,8 +965,8 @@ always @(posedge clk_pixel) begin
         // Convert signed two's complement → offset binary:
         // flip sign bit (bit 14).  Bit 15 = 0 (15-bit audio in 16-bit slot).
         // Explicit per-element assignment avoids unpacked-array ambiguity.
-        audio_reg[0] <= {1'b0, ~scaled_audio_left[14],  scaled_audio_left[13:0]};
-        audio_reg[1] <= {1'b0, ~scaled_audio_right[14], scaled_audio_right[13:0]};	
+        audio_reg[0] <= {scaled_audio_left[14], scaled_audio_left[14:0]};
+        audio_reg[1] <= {scaled_audio_right[14], scaled_audio_right[14:0]};	
 
     end
 end

--- a/src/tang/console60k/top.sv
+++ b/src/tang/console60k/top.sv
@@ -771,16 +771,25 @@ reg signed [14:0] scaled_audio_left;
 reg signed [14:0] scaled_audio_right;
 
 // generate 48khz audio clock
-reg clk_audio;
-reg [8:0] aclk_cnt;
+// An integer divider cannot land on 48kHz, and the truncation leaves the
+// stream running fast, so sinks drop a chunk of audio every few seconds. A
+// phase accumulator keeps the fractional part.
+localparam [31:0] AUDIO_INC = (64'd48000 <<< 32) / `PIXEL_CLOCK;
+reg [31:0] aclk_acc;
+reg        clk_audio;
+reg        aclk_tick;
 
 always @(posedge clk_pixel) begin
-    // divisor = pixel clock / 48000 / 2 - 1
-    if(aclk_cnt < `PIXEL_CLOCK / 48000 / 2 -1)
-      aclk_cnt <= aclk_cnt + 9'd1;
-    else begin
-       aclk_cnt <= 9'd0;
-       clk_audio <= ~clk_audio;
+    aclk_acc  <= aclk_acc + AUDIO_INC;
+    clk_audio <= aclk_acc[31];                 // msb of the accumulator = 48kHz
+    aclk_tick <= (clk_audio != aclk_acc[31]);  // high the cycle after each edge
+
+    // The sample word must not change on the same clk_pixel edge that toggles
+    // clk_audio: the hdmi module latches it on that very edge, so data and
+    // clock would race and the captured word could pick up wrong bits, which
+    // is audible as noisy samples. Updating one cycle later leaves the word
+    // stable for a full audio half period before it is sampled.
+    if(aclk_tick) begin
 
         // --- Stereo Mix (75/25)-------------------------------------------
         // 16-bit signed wires prevent any overflow; the result
@@ -832,8 +841,8 @@ always @(posedge clk_pixel) begin
         // Convert signed two's complement → offset binary:
         // flip sign bit (bit 14).  Bit 15 = 0 (15-bit audio in 16-bit slot).
         // Explicit per-element assignment avoids unpacked-array ambiguity.
-        audio_reg[0] <= {1'b0, ~scaled_audio_left[14],  scaled_audio_left[13:0]};
-        audio_reg[1] <= {1'b0, ~scaled_audio_right[14], scaled_audio_right[13:0]};	
+        audio_reg[0] <= {scaled_audio_left[14], scaled_audio_left[14:0]};
+        audio_reg[1] <= {scaled_audio_right[14], scaled_audio_right[14:0]};	
 
     end
 end

--- a/src/tang/mega138kpro/top.sv
+++ b/src/tang/mega138kpro/top.sv
@@ -922,16 +922,25 @@ reg signed [14:0] scaled_audio_left;
 reg signed [14:0] scaled_audio_right;
 
 // generate 48khz audio clock
-reg clk_audio;
-reg [8:0] aclk_cnt;
+// An integer divider cannot land on 48kHz, and the truncation leaves the
+// stream running fast, so sinks drop a chunk of audio every few seconds. A
+// phase accumulator keeps the fractional part.
+localparam [31:0] AUDIO_INC = (64'd48000 <<< 32) / `PIXEL_CLOCK;
+reg [31:0] aclk_acc;
+reg        clk_audio;
+reg        aclk_tick;
 
 always @(posedge clk_pixel) begin
-    // divisor = pixel clock / 48000 / 2 - 1
-    if(aclk_cnt < `PIXEL_CLOCK / 48000 / 2 -1)
-      aclk_cnt <= aclk_cnt + 9'd1;
-    else begin
-       aclk_cnt <= 9'd0;
-       clk_audio <= ~clk_audio;
+    aclk_acc  <= aclk_acc + AUDIO_INC;
+    clk_audio <= aclk_acc[31];                 // msb of the accumulator = 48kHz
+    aclk_tick <= (clk_audio != aclk_acc[31]);  // high the cycle after each edge
+
+    // The sample word must not change on the same clk_pixel edge that toggles
+    // clk_audio: the hdmi module latches it on that very edge, so data and
+    // clock would race and the captured word could pick up wrong bits, which
+    // is audible as noisy samples. Updating one cycle later leaves the word
+    // stable for a full audio half period before it is sampled.
+    if(aclk_tick) begin
 
         // --- Stereo Mix (75/25)-------------------------------------------
         // 16-bit signed wires prevent any overflow; the result
@@ -983,8 +992,8 @@ always @(posedge clk_pixel) begin
         // Convert signed two's complement → offset binary:
         // flip sign bit (bit 14).  Bit 15 = 0 (15-bit audio in 16-bit slot).
         // Explicit per-element assignment avoids unpacked-array ambiguity.
-        audio_reg[0] <= {1'b0, ~scaled_audio_left[14],  scaled_audio_left[13:0]};
-        audio_reg[1] <= {1'b0, ~scaled_audio_right[14], scaled_audio_right[13:0]};	
+        audio_reg[0] <= {scaled_audio_left[14], scaled_audio_left[14:0]};
+        audio_reg[1] <= {scaled_audio_right[14], scaled_audio_right[14:0]};	
 
     end
 end

--- a/src/tang/nano20k/top.sv
+++ b/src/tang/nano20k/top.sv
@@ -91,7 +91,10 @@ assign leds_n = ~leds;
 // SDRAM and flash clock: 85 MHz
 // Amiga clock: 7.09379 (Pixel/4)
    
-`define PIXEL_CLOCK 28375160
+// 27MHz crystal * 19/6 = 85.5MHz, divided by 3. The nominal PAL clock would
+// be 28.37516MHz, but this is the one the hardware actually runs at, and the
+// audio rate below is derived from it.
+`define PIXEL_CLOCK 28500000
 
 wire clk_pixel_x5;   
 wire pll_lock;   
@@ -893,17 +896,25 @@ reg signed [14:0] scaled_audio_left;
 reg signed [14:0] scaled_audio_right;
 
 // generate 48khz audio clock
-reg clk_audio;
-reg [8:0] aclk_cnt;
+// An integer divider cannot hit 48kHz: 28500000 / 48000 / 2 = 296.88, and the
+// truncation leaves the stream running fast, which makes sinks drop a chunk of
+// audio every few seconds. A phase accumulator keeps the fractional part.
+localparam [31:0] AUDIO_INC = (64'd48000 <<< 32) / `PIXEL_CLOCK;
+reg [31:0] aclk_acc;
+reg        clk_audio;
+reg        aclk_tick;
 
 always @(posedge clk_pixel) begin
-    // divisor = pixel clock / 48000 / 2 - 1
-    if(aclk_cnt < `PIXEL_CLOCK / 48000 / 2 -1)
-      aclk_cnt <= aclk_cnt + 9'd1;
-    else begin
-       aclk_cnt <= 9'd0;
-       clk_audio <= ~clk_audio;
+    aclk_acc  <= aclk_acc + AUDIO_INC;
+    clk_audio <= aclk_acc[31];                 // msb of the accumulator = 48kHz
+    aclk_tick <= (clk_audio != aclk_acc[31]);  // high the cycle after each edge
 
+    // The sample word must not change on the same clk_pixel edge that toggles
+    // clk_audio: the hdmi module latches it on that very edge, so data and
+    // clock would race and the captured word could pick up wrong bits, which
+    // is audible as noisy samples. Updating one cycle later leaves the word
+    // stable for a full audio half period before it is sampled.
+    if(aclk_tick) begin
         // --- Stereo Mix (75/25)-------------------------------------------
         // 16-bit signed wires prevent any overflow; the result
         // always fits in 15 bit and is truncated safely on assignment. 
@@ -954,8 +965,8 @@ always @(posedge clk_pixel) begin
         // Convert signed two's complement → offset binary:
         // flip sign bit (bit 14).  Bit 15 = 0 (15-bit audio in 16-bit slot).
         // Explicit per-element assignment avoids unpacked-array ambiguity.
-        audio_reg[0] <= {1'b0, ~scaled_audio_left[14],  scaled_audio_left[13:0]};
-        audio_reg[1] <= {1'b0, ~scaled_audio_right[14], scaled_audio_right[13:0]};	
+        audio_reg[0] <= {scaled_audio_left[14],  scaled_audio_left[14:0]};
+        audio_reg[1] <= {scaled_audio_right[14], scaled_audio_right[14:0]};	
 
     end
 end

--- a/src/tang/nano20k/top_020.sv
+++ b/src/tang/nano20k/top_020.sv
@@ -93,7 +93,10 @@ assign leds_n = ~leds;
 // SDRAM and flash clock: 85 MHz
 // Amiga clock: 7.09379 (Pixel/4)
    
-`define PIXEL_CLOCK 28375160
+// 27MHz crystal * 19/6 = 85.5MHz, divided by 3. The nominal PAL clock would
+// be 28.37516MHz, but this is the one the hardware actually runs at, and the
+// audio rate below is derived from it.
+`define PIXEL_CLOCK 28500000
 
 wire clk_pixel_x5;   
 wire pll_lock;   
@@ -903,17 +906,25 @@ reg signed [14:0] scaled_audio_left;
 reg signed [14:0] scaled_audio_right;
 
 // generate 48khz audio clock
-reg clk_audio;
-reg [8:0] aclk_cnt;
+// An integer divider cannot hit 48kHz: 28500000 / 48000 / 2 = 296.88, and the
+// truncation leaves the stream running fast, which makes sinks drop a chunk of
+// audio every few seconds. A phase accumulator keeps the fractional part.
+localparam [31:0] AUDIO_INC = (64'd48000 <<< 32) / `PIXEL_CLOCK;
+reg [31:0] aclk_acc;
+reg        clk_audio;
+reg        aclk_tick;
 
 always @(posedge clk_pixel) begin
-    // divisor = pixel clock / 48000 / 2 - 1
-    if(aclk_cnt < `PIXEL_CLOCK / 48000 / 2 -1)
-      aclk_cnt <= aclk_cnt + 9'd1;
-    else begin
-       aclk_cnt <= 9'd0;
-       clk_audio <= ~clk_audio;
+    aclk_acc  <= aclk_acc + AUDIO_INC;
+    clk_audio <= aclk_acc[31];                 // msb of the accumulator = 48kHz
+    aclk_tick <= (clk_audio != aclk_acc[31]);  // high the cycle after each edge
 
+    // The sample word must not change on the same clk_pixel edge that toggles
+    // clk_audio: the hdmi module latches it on that very edge, so data and
+    // clock would race and the captured word could pick up wrong bits, which
+    // is audible as noisy samples. Updating one cycle later leaves the word
+    // stable for a full audio half period before it is sampled.
+    if(aclk_tick) begin
         // --- Stereo Mix (75/25)-------------------------------------------
         // 16-bit signed wires prevent any overflow; the result
         // always fits in 15 bit and is truncated safely on assignment. 
@@ -964,8 +975,8 @@ always @(posedge clk_pixel) begin
         // Convert signed two's complement → offset binary:
         // flip sign bit (bit 14).  Bit 15 = 0 (15-bit audio in 16-bit slot).
         // Explicit per-element assignment avoids unpacked-array ambiguity.
-        audio_reg[0] <= {1'b0, ~scaled_audio_left[14],  scaled_audio_left[13:0]};
-        audio_reg[1] <= {1'b0, ~scaled_audio_right[14], scaled_audio_right[13:0]};	
+        audio_reg[0] <= {scaled_audio_left[14],  scaled_audio_left[14:0]};
+        audio_reg[1] <= {scaled_audio_right[14], scaled_audio_right[14:0]};	
 
     end
 end

--- a/src/tang/primer25k/top.sv
+++ b/src/tang/primer25k/top.sv
@@ -704,16 +704,25 @@ reg signed [14:0] scaled_audio_left;
 reg signed [14:0] scaled_audio_right;
 
 // generate 48khz audio clock
-reg clk_audio;
-reg [8:0] aclk_cnt;
+// An integer divider cannot land on 48kHz, and the truncation leaves the
+// stream running fast, so sinks drop a chunk of audio every few seconds. A
+// phase accumulator keeps the fractional part.
+localparam [31:0] AUDIO_INC = (64'd48000 <<< 32) / `PIXEL_CLOCK;
+reg [31:0] aclk_acc;
+reg        clk_audio;
+reg        aclk_tick;
 
 always @(posedge clk_pixel) begin
-    // divisor = pixel clock / 48000 / 2 - 1
-    if(aclk_cnt < `PIXEL_CLOCK / 48000 / 2 -1)
-      aclk_cnt <= aclk_cnt + 9'd1;
-    else begin
-       aclk_cnt <= 9'd0;
-       clk_audio <= ~clk_audio;
+    aclk_acc  <= aclk_acc + AUDIO_INC;
+    clk_audio <= aclk_acc[31];                 // msb of the accumulator = 48kHz
+    aclk_tick <= (clk_audio != aclk_acc[31]);  // high the cycle after each edge
+
+    // The sample word must not change on the same clk_pixel edge that toggles
+    // clk_audio: the hdmi module latches it on that very edge, so data and
+    // clock would race and the captured word could pick up wrong bits, which
+    // is audible as noisy samples. Updating one cycle later leaves the word
+    // stable for a full audio half period before it is sampled.
+    if(aclk_tick) begin
 
         // --- Stereo Mix (75/25)-------------------------------------------
         // 16-bit signed wires prevent any overflow; the result
@@ -765,8 +774,8 @@ always @(posedge clk_pixel) begin
         // Convert signed two's complement → offset binary:
         // flip sign bit (bit 14).  Bit 15 = 0 (15-bit audio in 16-bit slot).
         // Explicit per-element assignment avoids unpacked-array ambiguity.
-        audio_reg[0] <= {1'b0, ~scaled_audio_left[14],  scaled_audio_left[13:0]};
-        audio_reg[1] <= {1'b0, ~scaled_audio_right[14], scaled_audio_right[13:0]};	
+        audio_reg[0] <= {scaled_audio_left[14], scaled_audio_left[14:0]};
+        audio_reg[1] <= {scaled_audio_right[14], scaled_audio_right[14:0]};	
 
     end
 end


### PR DESCRIPTION
Extended to every board, as asked.

Three independent hdmi audio defects, all present in every platform top.

### Offset binary samples

IEC 60958 carries signed two's complement pcm, but the samples were
converted to offset binary by flipping the sign bit:

```verilog
audio_reg[0] <= {1'b0, ~scaled_audio_left[14],  scaled_audio_left[13:0]};
```

That puts a constant half scale dc on the output, which many sinks
reproduce as a permanent hum. The 15 bit sample is now sign extended.

### The sample word raced its own clock

`audio_reg` was written in the same `clk_pixel` branch that toggles
`clk_audio`, and `hdmi.sv` latches `audio_sample_word` on the `clk_audio`
edge. Data and clock changed together, so the captured word picked up wrong
bits depending on how the two paths happened to be routed - the samples
sounded gritty in some builds and clean in others, with no source change in
between. The mixing and the sample register now run one cycle after the
toggle, leaving the word stable for a full audio half period.

### The sample rate was never 48kHz

The audio clock came from an integer divider:

```verilog
if(aclk_cnt < `PIXEL_CLOCK / 48000 / 2 - 1)
```

The truncation leaves the stream running fast while the info frame declares
48000Hz. The surplus fills the sink's buffer until it drops a chunk of
audio, which is heard as the music briefly jumping every few seconds - very
noticeable under demo music. A phase accumulator keeps the fractional part;
on the tang nano20k that is 47999.999Hz instead of 48141Hz.

The step is computed from `PIXEL_CLOCK` at elaboration time rather than
written out per board, so each target only needs its define to be right:

```verilog
localparam [31:0] AUDIO_INC = (64'd48000 <<< 32) / `PIXEL_CLOCK;
```

### One thing worth checking

On the tang nano20k `PIXEL_CLOCK` was the nominal PAL 28.37516MHz while the
pll actually makes 27MHz * 19/6 / 3 = 28.5MHz. That define is corrected
here, and it is what made the audio rate wrong in the first place.

Other boards may have the same discrepancy - gw3a_20 declares 28400000
while its pll settings suggest 50MHz * 17 / 6 / 5 = 28.333MHz - but I have
no way to verify those, so I have left their defines alone. Since the audio
rate now follows the define, anyone with the hardware may want to check
them.

### Testing

Builds verified for tang nano20k (both variants), console60k, primer25k and
mistle gw3a_20. The constant arithmetic was checked separately to make sure
the 64 bit expression is evaluated exactly.

Audio verified by ear on a tang nano20k: no hum, clean samples, and no
periodic jump.
