### PR TITLE
AGA chipset, 68020 and a cpu cache for the Tang Nano 20K

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -22,7 +22,7 @@ TG68K_FILES=TG68KdotC_Kernel.v
 
 # Minimig-AGA
 MINIMIG_DIR=../src/minimig-aga
-MINIMIG_FILES=../nanomig.v amiga_clk.v cpu_wrapper.v minimig.v 
+MINIMIG_FILES=../nanomig.v amiga_clk.v cpu_wrapper.v cpu_cache_new.v dpram.v minimig.v 
 MINIMIG_FILES+=ciaa.v ciab.v cia_int.v cia_timera.v cia_timerb.v cia_timerd.v 
 MINIMIG_FILES+=paula.v paula_uart.v paula_audio_channel.v paula_audio_mixer.v paula_audio.v paula_audio_volume.v paula_floppy_fifo.v paula_floppy.v paula_intcontroller.v
 MINIMIG_FILES+=agnus.v agnus_audiodma.v agnus_blitter_adrgen.v agnus_blitter_minterm.v agnus_diskdma.v agnus_beamcounter.v agnus_blitter_barrelshifter.v agnus_blitter.v agnus_refresh.v agnus_bitplanedma.v agnus_blitter_fill.v agnus_copper.v agnus_spritedma.v
@@ -32,13 +32,13 @@ MINIMIG_FILES+=../minimig/Amber.v userio.v
 TB=nanomig_tb
 
 MISC_DIR=../src/misc
-MISC_FILES=sd_card.v sd_rw.v sdcmd_ctrl.v
+MISC_FILES=sd_card.v sd_rw.v sdcmd_ctrl.v sdram.sv
 
 VERILATOR_DIR=/usr/local/share/verilator/include
 VERILATOR_FILES=verilated.cpp verilated_vcd_c.cpp verilated_threads.cpp
 
-HDL_FILES=$(TB).v $(MINIMIG_FILES:%=$(MINIMIG_DIR)/%) $(FX68K_FILES:%=$(FX68K_DIR)/%)
-HDL_FILES+=$(MISC_FILES:%=$(MISC_DIR)/%) 
+HDL_FILES=$(TB).v sdr_chip_model.v $(MINIMIG_FILES:%=$(MINIMIG_DIR)/%) $(FX68K_FILES:%=$(FX68K_DIR)/%)
+HDL_FILES+=$(MISC_FILES:%=$(MISC_DIR)/%)
 HDL_FILES+=$(TG68K_FILES:%=$(TG68K_DIR)/%)
 
 EXTRA_CFLAGS = `sdl2-config --cflags`

--- a/sim/nanomig_tb.cpp
+++ b/sim/nanomig_tb.cpp
@@ -23,6 +23,7 @@
 #include "Vnanomig_tb_minimig.h"
 #include "Vnanomig_tb_paula.h"
 #include "Vnanomig_tb_paula_floppy.h"
+#include "Vnanomig_tb_sdr_chip_model.h"
 
 #include "verilated.h"
 #include "verilated_fst_c.h"
@@ -327,10 +328,13 @@ static uint64_t GetTickCountMs() {
 unsigned short ram[8*512*1024];  // 8 Megabytes
 
 void load_kick(void) {
-  printf("Loading kick into last 512k of 8MB ram\n");
-  FILE *fd = fopen(KICK, "rb");
+  // the KICK environment variable overrides the compiled-in rom name
+  const char *kick = getenv("KICK");
+  if(!kick) kick = KICK;
+  printf("Loading kick '%s' into last 512k of 8MB ram\n", kick);
+  FILE *fd = fopen(kick, "rb");
   if(!fd) { perror("load kick"); exit(-1); }
-  
+
   int len = fread(ram+(0x780000/2), 1024, 512, fd);
   if(len != 512) {
     if(len != 256) {
@@ -343,6 +347,28 @@ void load_kick(void) {
     }
   }
   fclose(fd);
+}
+
+// copy the ram[] array (kick rom) into the verilog sdram chip model.
+// ram[] holds raw big endian bytes, the 32 bit sdram word c is
+// { 16 bit word 2c, 16 bit word 2c+1 } with big endian words.
+// With RANDMEM=1 in the environment everything outside the kickstart
+// image is filled with pseudo random junk like real power-up sdram,
+// instead of the zeroes of the ram[] array.
+void preload_sdram_model(void) {
+  unsigned char *b = (unsigned char*)ram;
+  int randmem = getenv("RANDMEM") != NULL;
+  unsigned lcg = 0x12345678;
+  for(unsigned c=0;c<2097152;c++) {
+    unsigned v = ((unsigned)b[4*c+0]<<24) | ((unsigned)b[4*c+1]<<16) |
+                 ((unsigned)b[4*c+2]<< 8) |  (unsigned)b[4*c+3];
+    if(randmem && (c < (0x780000/4) || c >= (0x800000/4))) {
+      lcg = lcg * 1664525u + 1013904223u;
+      v = lcg;
+    }
+    tb->nanomig_tb->__PVT__sdram_chip->mem[c] = v;
+  }
+  printf("SDRAM chip model preloaded%s\n", randmem ? " (random junk outside kick)" : "");
 }
 
 // The amiga does MFM data encoding in software and the floppy controller
@@ -627,6 +653,23 @@ void tick(int c) {
 	// big edian read
 	tb->ramdata_in = 256*ram_b[0] + ram_b[1];
 
+	// AGA wide fetch: words 1..3 of the 64 bit aligned group around the
+	// current address, like the burst read of the TN20k sdram controller
+	unsigned char *cb = (unsigned char*)(ram+(tb->ram_address & ~3u));
+	tb->chip48 = ((uint64_t)((cb[2]<<8)|cb[3])<<32) |
+	             ((uint64_t)((cb[4]<<8)|cb[5])<<16) |
+	              (uint64_t)((cb[6]<<8)|cb[7]);
+
+	// optionally log bitplane area DMA reads for a short time window
+	static int dmalog = -1;
+	if(dmalog < 0) dmalog = getenv("DMALOG") != NULL;
+	if(dmalog) {
+	  uint32_t ba = tb->ram_address<<1;
+	  if(ba >= 0x800 && ba < 0x14800 &&
+	     simulation_time > 1.0 && simulation_time < 1.0008)
+	    printf("DMA RD %.6fms %06x\n", simulation_time*1000, ba);
+	}
+
 	// ===== check for kick 1.3 fatal error routine being executed =====
 	// these blink the power led
 	static int fatal = 0;
@@ -657,7 +700,15 @@ void tick(int c) {
   
   }
 
-  tb->eval();
+  // generate three 85MHz half-periods per 28MHz half-period. The first
+  // 85MHz edge is aligned with the 28MHz edge like on the real board where
+  // both clocks come from the same PLL (clk28 = clk85 / 3)
+  static int clk85_state = 0;
+  for(int k=0;k<3;k++) {
+    clk85_state = !clk85_state;
+    tb->clk85 = clk85_state;
+    tb->eval();
+  }
 
   if(c) capture_video();
 
@@ -697,14 +748,29 @@ int main(int argc, char **argv) {
   tb->trace(trace, 99);
   trace->open("nanomig.fst");
 
+  tb->clk85 = 0;
+  preload_sdram_model();
+
   sd_init();
   
   tb->por = 1;
   tb->reset = 1;
-  tb->memory_config = 0x00; // 0x00=512k, 0x01=1M, 0x0f=3.5M
-  tb->fastram_config = 0;   // 0=none, 1=2MB, 2=4MB
+  // CHIPMEM selects the chip ram size the same way the menu does
+  // (0=512k, 1=1M, 2=1.5M, 3=2M in the low two bits)
+  tb->memory_config = getenv("CHIPMEM") ? atoi(getenv("CHIPMEM")) : 0x00;
+  tb->fastram_config = getenv("FASTRAM") ? atoi(getenv("FASTRAM")) : 0;   // 0=none, 1=2MB, 2=4MB
   tb->floppy_config = 0x5;  // 1 = one fast drive, 5 = two fast drives
   tb->ide_config = 0x0;     // 0=no drive, 7=two drives
+
+  // AGA=1 in the environment enables the AGA chipset and the 68020
+  int aga_mode = getenv("AGA") != NULL;
+  // CHIPSET/CPU override the coupled AGA default so chipset and cpu effects
+  // can be told apart (CHIPSET=0 ocs / 1 aga, CPU=0 68000 / 2 68020)
+  int chipset_aga = getenv("CHIPSET") ? atoi(getenv("CHIPSET")) : aga_mode;
+  int cpu_sel     = getenv("CPU")     ? atoi(getenv("CPU"))     : (aga_mode ? 2 : 0);
+  tb->chipset_config = chipset_aga ? 0x18 : 0x00;  // bits 4:3 = 11 -> AGA
+  tb->cpu_config = cpu_sel;                        // 2 = 68020
+  printf("config: chipset=%s cpu=%s\n", chipset_aga?"AGA":"OCS", cpu_sel==2?"68020":"68000");
 
   /* run for a while */
   while(

--- a/sim/nanomig_tb.v
+++ b/sim/nanomig_tb.v
@@ -2,7 +2,8 @@
 
 module nanomig_tb
   (
-   input	 clk, // 28mhz
+   input	 clk,   // 28mhz
+   input	 clk85, // 85mhz, 3x clk, edge aligned (like the PLL on the real board)
    output	 clk_7m, 
    output	 clk7_en,
    output	 clk7n_en,
@@ -30,6 +31,8 @@ module nanomig_tb
    input [2:0]	 fastram_config,
    input [3:0]	 floppy_config,
    input [5:0]	 ide_config,
+   input [5:0]	 chipset_config, // bit 4:3 = 11 -> AGA
+   input [1:0]	 cpu_config,     // 0=68000, 2=68020
    
    output	 sdclk,
    output	 sdcmd,
@@ -49,6 +52,7 @@ module nanomig_tb
    // external ram/rom interface
    output [15:0] ram_data, // sram data bus
    input [15:0]	 ramdata_in, // sram data bus in
+   input [47:0]	 chip48, // upper 48 bit of a 64 bit aligned read (AGA wide fetch)
    output [23:1] ram_address, // sram address bus
    output	 _ram_bhe, // sram upper byte select
    output	 _ram_ble, // sram lower byte select
@@ -261,12 +265,18 @@ nanomig nanomig (
 
 		 .pwr_led(pwr_led),
 		 .fdd_led(fdd_led),
+`ifndef DISABLE_IDE
 		 .hdd_led(hdd_led),
+`endif
 
 		 .memory_config(memory_config),
 		 .fastram_config(fastram_config),
 		 .floppy_config(floppy_config),
+`ifndef DISABLE_IDE
 		 .ide_config(ide_config),
+`endif
+		 .chipset_config(chipset_config),
+		 .cpu_config(cpu_config),
 		 
 		 .hs(hs_n),
 		 .vs(vs_n),
@@ -294,13 +304,104 @@ nanomig nanomig (
 		 
 		 // (s(d))ram interface
 		 .ram_data(ram_data_i),       // sram data bus
-		 .ramdata_in(ramdata_in),     // sram data bus in
-		 .chip48(48'h0),              // big chip read, needed for AGA only
+		 .ramdata_in(sdram_dout),     // sram data bus in (from the real sdram controller)
+		 .chip48(chip48_sdram),       // big chip read, needed for AGA only
 		 .ram_address(ram_address_i), // sram address bus
 		 ._ram_bhe(_ram_bhe_i),       // sram upper byte select
 		 ._ram_ble(_ram_ble_i),       // sram lower byte select
 		 ._ram_we(_ram_we_i),         // sram write enable
-		 ._ram_oe(_ram_oe_i)          // sram output enable
+		 ._ram_oe(_ram_oe_i),         // sram output enable
+		 .refresh(ram_refresh),       // refresh cycle request
+
+		 // direct (fast) ram path of the cpu, served by the sdram's second port
+		 .fastram_sel(fastram_sel),
+		 .fastram_addr(fastram_addr),
+		 .fastram_lds(fastram_lds),
+		 .fastram_uds(fastram_uds),
+		 .fastram_dout(fastram_dout),
+		 .fastram_chip48(fastram_chip48),
+		 .fastram_din(fastram_din),
+		 .fastram_wr(fastram_wr),
+		 .fastram_ready(fastram_ready)
 		 );
-   
+
+wire        fastram_sel;
+wire [22:1] fastram_addr;
+wire        fastram_lds, fastram_uds, fastram_wr, fastram_ready;
+wire [15:0] fastram_dout, fastram_din;
+wire [47:0] fastram_chip48;
+
+// ---------------------------------------------------------------------------
+// ------ the real sdram controller of the tang nano 20k + a chip model ------
+// ---------------------------------------------------------------------------
+// This replicates the glue logic of src/tang/nano20k/top_020.sv so the
+// simulation exercises the exact same 85 MHz burst datapath as the hardware
+// (including the AGA chip48 wide fetch).
+
+wire        ram_refresh;
+wire [15:0] sdram_dout;
+wire [47:0] chip48_sdram;
+
+// run a counter at 28Mhz synchronous to the 7Mhz bus cycle (like top_020.sv)
+reg  [1:0]  cyc;
+always @(posedge clk)
+  if(clk7_en) cyc <= 2'd0;
+  else        cyc <= cyc + 2'd1;
+
+wire        sdram_access = (!_ram_oe || !_ram_we);
+wire        sdram_sync   = !cyc;
+
+wire [31:0] sd_dq;
+wire [10:0] sd_addr;
+wire [3:0]  sd_dqm;
+wire [1:0]  sd_ba;
+wire        sd_cs_n, sd_ras_n, sd_cas_n, sd_we_n;
+
+sdram #(.DATA_WIDTH(32), .RAS_WIDTH(11), .CAS_WIDTH(8), .CHIP48_BURST(1) ) sdram (
+	.sd_data    ( sd_dq     ),
+	.sd_addr    ( sd_addr   ),
+	.sd_dqm     ( sd_dqm    ),
+	.sd_ba      ( sd_ba     ),
+	.sd_cs      ( sd_cs_n   ),
+	.sd_we      ( sd_we_n   ),
+	.sd_ras     ( sd_ras_n  ),
+	.sd_cas     ( sd_cas_n  ),
+
+	.clk        ( clk85     ),
+	.reset_n    ( ~por      ),
+
+	.ready      (           ),
+	.sync       ( sdram_sync ),
+	.refresh    ( ram_refresh ),
+
+	.din        ( ram_data  ),
+	.dout       ( sdram_dout ),
+	.chip48     ( chip48_sdram ),
+	.addr       ( ram_address[22:1] ),
+	.ds         ( { _ram_bhe, _ram_ble } ),
+	.cs         ( sdram_access ),
+	.we         ( !_ram_we  ),
+
+	.p2_din     ( fastram_din    ),
+	.p2_dout    ( fastram_dout   ),
+	.p2_chip48  ( fastram_chip48 ),
+	.p2_addr    ( fastram_addr   ),
+	.p2_ds      ( { fastram_uds, fastram_lds } ),
+	.p2_cs      ( fastram_sel    ),
+	.p2_we      ( fastram_wr     ),
+	.p2_ack     ( fastram_ready  )
+);
+
+sdr_chip_model sdram_chip (
+	.clk   ( clk85    ),
+	.dq    ( sd_dq    ),
+	.addr  ( sd_addr  ),
+	.dqm   ( sd_dqm   ),
+	.ba    ( sd_ba    ),
+	.cs_n  ( sd_cs_n  ),
+	.ras_n ( sd_ras_n ),
+	.cas_n ( sd_cas_n ),
+	.we_n  ( sd_we_n  )
+);
+
 endmodule

--- a/sim/sdr_chip_model.v
+++ b/sim/sdr_chip_model.v
@@ -1,0 +1,84 @@
+// sdr_chip_model.v
+//
+// Behavioral model of the Tang Nano 20K's in-package 32 bit SDR SDRAM,
+// just detailed enough for the NanoMig sdram.sv controller: ACTIVE/READ/
+// WRITE/LOAD MODE with CAS latency 2, burst length 1 or 2 (sequential,
+// wrapping within the aligned pair), byte masks on writes, single writes
+// (write burst disabled). Refresh and precharge are accepted and ignored.
+//
+// The memory array is verilator-public so the testbench can preload the
+// kickstart image directly.
+
+module sdr_chip_model (
+   input	 clk,     // controller/SDRAM clock (85MHz)
+   inout [31:0]	 dq,
+   input [10:0]	 addr,
+   input [3:0]	 dqm,
+   input [1:0]	 ba,
+   input	 cs_n,
+   input	 ras_n,
+   input	 cas_n,
+   input	 we_n
+);
+
+/* verilator no_inline_module */
+
+// 8MB as 2M x 32
+reg [31:0] mem [0:2097151] /*verilator public_flat_rw*/;
+
+reg [10:0] row [0:3];
+reg	   burst2;         // mode register burst length 2
+
+wire [2:0] command = {ras_n, cas_n, we_n};
+localparam CMD_ACTIVE    = 3'b011;
+localparam CMD_READ      = 3'b101;
+localparam CMD_WRITE     = 3'b100;
+localparam CMD_LOAD_MODE = 3'b000;
+
+// read data pipeline for CAS latency 2
+reg	    v0, v1;
+reg [31:0]  d0, d1;
+reg	    pend;         // second beat of a burst-2 read pending
+reg [20:0]  pa;           // address of the first beat
+
+wire [20:0] col_addr = {ba, row[ba], addr[7:0]};
+
+always @(posedge clk) begin
+   // advance the CL pipeline
+   v1 <= v0;
+   d1 <= d0;
+   v0 <= 1'b0;
+
+   if (pend) begin
+      // sequential burst-2 wraps within the aligned pair
+      d0   <= mem[{pa[20:1], ~pa[0]}];
+      v0   <= 1'b1;
+      pend <= 1'b0;
+   end
+
+   if (!cs_n) begin
+      case (command)
+	CMD_LOAD_MODE: burst2 <= (addr[2:0] == 3'b001);
+	CMD_ACTIVE:    row[ba] <= addr;
+	CMD_READ: begin
+	   d0   <= mem[col_addr];
+	   v0   <= 1'b1;
+	   pa   <= col_addr;
+	   pend <= burst2;
+	end
+	CMD_WRITE: begin
+	   // single write with byte masks (write burst disabled)
+	   if (!dqm[3]) mem[col_addr][31:24] <= dq[31:24];
+	   if (!dqm[2]) mem[col_addr][23:16] <= dq[23:16];
+	   if (!dqm[1]) mem[col_addr][15: 8] <= dq[15: 8];
+	   if (!dqm[0]) mem[col_addr][ 7: 0] <= dq[ 7: 0];
+	   pend <= 1'b0;
+	end
+	default: ;  // nop/refresh/precharge ignored
+      endcase
+   end
+end
+
+assign dq = v1 ? d1 : 32'hzzzzzzzz;
+
+endmodule

--- a/sim/test_rom/aga_test.s
+++ b/sim/test_rom/aga_test.s
@@ -1,0 +1,242 @@
+	;; aga_test.s
+	;; AGA test rom for the NanoMig simulation
+	;;
+	;; Sets up an AGA screen: 8 bitplanes, lores, FMODE=3 (64 bit
+	;; bitplane fetch via the chip48 side band), 40 vertical stripes
+	;; of 8 pixels each using color indices 0..39. Indices 32..39
+	;; only exist on AGA (palette bank 1). A frame counter is printed
+	;; into plane 0 to show the CPU is alive.
+	;;
+	;; If the chip48 wide fetch path is broken, 3 of every 4 stripe
+	;; columns render with corrupted plane data.
+
+VIDMEM	EQU	2048		; plane 0, planes are 10240 bytes apart
+PLSIZE	EQU	10240		; 40*256 bytes per plane
+COPPER  EQU     $220		; copperlist in RAM
+XPOS	EQU     $200
+YPOS	EQU     $202
+
+	;; amiga like rom header
+	ORG $f80000
+
+        bra.s   start-1   	; -1? wtf ...
+        dc.w    $4ef9           ; jmp ...
+
+        dc.l    $f80030
+        dc.l    $f80008
+
+        ORG $f80030
+
+	;; actual code starting point
+start:
+        ;; wait >80ms for minimig-aga syctrl reset to be gone
+        move    #60000,d0
+iwlp:   dbra    d0,iwlp
+
+	move.l  #$100,sp	; use ram below $100 as stack
+	move.b	#3,$bfe201	; LED and OVL are outputs
+	move.b	#2,$bfe001	; switch rom overlay off
+
+	bsr	fillplanes
+	bsr	setpalette
+	bsr	startcopper
+
+	;; print the chipset id registers once:
+	;; VPOSR (Alice id in bits 14..8) and DENISEID/LISAID
+	clr.w	XPOS
+	move.w	#1,YPOS
+	move.w	$dff004,d0
+	swap	d0
+	move.w	$dff07c,d0
+	jsr	printlong
+
+	;; just count ...
+	clr.l	d0
+prt_lp:	clr.w	XPOS
+	clr.w	YPOS
+	jsr 	printlong
+	addq.l	#1,d0
+	bra.s	prt_lp
+
+	;; fill the 8 bitplanes with vertical stripes:
+	;; byte column i (0..39) of plane p is $ff when bit p of i is set,
+	;; so the 8 pixels of column i all use color index i
+fillplanes:
+	moveq	#0,d2		; plane number
+plp:	move.l	#VIDMEM,a0
+	move.l	d2,d0
+	mulu	#PLSIZE,d0
+	add.l	d0,a0
+	move.w	#256-1,d3	; rows
+rowlp:	moveq	#0,d4		; byte column
+collp:	move.w	d4,d0
+	move.w	d2,d1
+	lsr.w	d1,d0
+	and.w	#1,d0
+	neg.b	d0		; 0 or $ff
+	move.b	d0,(a0)+
+	addq.w	#1,d4
+	cmp.w	#40,d4
+	bne.s	collp
+	dbra	d3,rowlp
+	addq.w	#1,d2
+	cmp.w	#8,d2
+	bne.s	plp
+	rts
+
+	;; write 40 palette entries: 32 into bank 0 and
+	;; 8 into bank 1 (indices 32..39, AGA only)
+setpalette:
+	lea	$dff000,a5
+	lea	coltab,a0
+	move.w	#$0000,$106(a5)	; BPLCON3: bank 0
+	lea	$180(a5),a1
+	moveq	#32-1,d0
+c0lp:	move.w	(a0)+,(a1)+
+	dbra	d0,c0lp
+	move.w	#$2000,$106(a5)	; BPLCON3: bank 1
+	lea	$180(a5),a1
+	moveq	#8-1,d0
+c1lp:	move.w	(a0)+,(a1)+
+	dbra	d0,c1lp
+	move.w	#$0000,$106(a5)	; back to bank 0
+	rts
+
+startcopper:
+	;; copy copper list to ram
+	move.l	#(copperlist_end-copperlist)/4-1,d1
+	move.l	#copperlist,a0
+	move.l	#COPPER,a1
+cplp:	move.l	(a0)+,(a1)+
+	dbra	d1,cplp
+
+	move.l	#COPPER,$dff080 ; load copper list
+	move.w	$dff088,d0      ; start copper
+	move.w	#$8380,$dff096  ; init dma controller
+	move.w	#$20,$dff1dc	; PAL
+
+	;; reset cursor
+	clr.w	XPOS
+	clr.w	YPOS
+
+	rts
+
+	IFND	FMODEVAL
+FMODEVAL	EQU	3
+	ENDC
+
+copperlist:
+	dc.w $01fc,FMODEVAL ; FMODE: 64 bit bitplane fetch (or 0 for 16 bit)
+	dc.w $0100,$0210 ; BPLCON0: 8 bitplanes (BPU3), lores, color
+	dc.w $0102,$0000 ; BPLCON1: no scroll
+	dc.w $0104,$0000 ; BPLCON2
+	;; with the wide fetch modes the hardware always completes full
+	;; 64 bit blocks past DDFSTOP. With DDFSTRT/STOP $38/$d0 six
+	;; blocks of 8 bytes are fetched per line (48 bytes) while the
+	;; row is only 40 bytes wide, so a -8 modulo compensates.
+	IFEQ	FMODEVAL
+	dc.w $0108,$0000 ; BPL1MOD
+	dc.w $010a,$0000 ; BPL2MOD
+	ELSE
+	dc.w $0108,$fff8 ; BPL1MOD
+	dc.w $010a,$fff8 ; BPL2MOD
+	ENDC
+	dc.w $0092,$0038 ; display data fetch start
+	dc.w $0094,$00d0 ; display data fetch stop
+	dc.w $008e,$2c81 ; \__ PAL 320x256
+	dc.w $0090,$2cc1 ; /
+	dc.w $00e0,$0000 ; bitplane 1 (VIDMEM + 0*PLSIZE = $000800)
+	dc.w $00e2,$0800
+	dc.w $00e4,$0000 ; bitplane 2 ($003000)
+	dc.w $00e6,$3000
+	dc.w $00e8,$0000 ; bitplane 3 ($005800)
+	dc.w $00ea,$5800
+	dc.w $00ec,$0000 ; bitplane 4 ($008000)
+	dc.w $00ee,$8000
+	dc.w $00f0,$0000 ; bitplane 5 ($00a800)
+	dc.w $00f2,$a800
+	dc.w $00f4,$0000 ; bitplane 6 ($00d000)
+	dc.w $00f6,$d000
+	dc.w $00f8,$0000 ; bitplane 7 ($00f800)
+	dc.w $00fa,$f800
+	dc.w $00fc,$0001 ; bitplane 8 ($012000)
+	dc.w $00fe,$2000
+
+	dc.w $ffff,$fffe ; End of copperlist
+copperlist_end:
+
+	;; 40 colors: red -> yellow -> green -> cyan -> blue gradient
+coltab:
+	dc.w $f00,$f20,$f40,$f60,$f80,$fa0,$fc0,$fe0 ;  0.. 7
+	dc.w $ff0,$df0,$bf0,$9f0,$7f0,$5f0,$3f0,$1f0 ;  8..15
+	dc.w $0f0,$0f2,$0f4,$0f6,$0f8,$0fa,$0fc,$0fe ; 16..23
+	dc.w $0ff,$0df,$0bf,$09f,$07f,$05f,$03f,$01f ; 24..31
+	dc.w $00f,$20f,$40f,$60f,$80f,$a0f,$c0f,$f0f ; 32..39 (AGA bank 1)
+
+	;; print long given in D0
+printlong:
+	swap	d0
+	jsr 	printword
+	swap	d0
+	jsr 	printword
+	rts
+
+printword:
+	movem.l	d0/d1,-(sp)
+	move.w	#8,d1
+	rol.w	d1,d0
+	jsr 	printbyte
+	rol.w	d1,d0
+	jsr 	printbyte
+	movem.l	(sp)+,d0/d1
+	rts
+
+printbyte:
+	movem.l	d0/d1,-(sp)
+	move	d0,d1
+	lsr	#4,d0
+	jsr 	printdigit
+	move	d1,d0
+	jsr 	printdigit
+	movem.l	(sp)+,d0/d1
+	rts
+
+	;; print hex digit given in D0 into plane 0
+printdigit:
+	movem.l	d0/a0-a1,-(sp)
+	move.l	#hexchars,a0
+	and.l	#15,d0
+	lsl	#3,d0
+	add.l	d0,a0
+	move.l	#VIDMEM,a1
+	move	YPOS,d0
+	mulu	#(8*40),d0
+	add.l	d0,a1
+	add	XPOS,d0
+	ext.l	d0
+	add.l	d0,a1
+	moveq	#7,d0
+pd0:	move.b	(a0)+,(a1)+
+	add.l	#(40-1),a1
+	dbra	d0,pd0
+	add	#1,XPOS
+	movem.l	(sp)+,d0/a0-a1
+	rts
+
+hexchars:
+	dc.b $7C, $C6, $CE, $DE, $F6, $E6, $7C, $00   ; 0
+	dc.b $30, $70, $30, $30, $30, $30, $FC, $00   ; 1
+	dc.b $78, $CC, $0C, $38, $60, $CC, $FC, $00   ; 2
+	dc.b $78, $CC, $0C, $38, $0C, $CC, $78, $00   ; 3
+	dc.b $1C, $3C, $6C, $CC, $FE, $0C, $1E, $00   ; 4
+	dc.b $FC, $C0, $F8, $0C, $0C, $CC, $78, $00   ; 5
+	dc.b $38, $60, $C0, $F8, $CC, $CC, $78, $00   ; 6
+	dc.b $FC, $CC, $0C, $18, $30, $30, $30, $00   ; 7
+	dc.b $78, $CC, $CC, $78, $CC, $CC, $78, $00   ; 8
+	dc.b $78, $CC, $CC, $7C, $0C, $18, $70, $00   ; 9
+	dc.b $30, $78, $CC, $CC, $FC, $CC, $CC, $00   ; A
+	dc.b $FC, $66, $66, $7C, $66, $66, $FC, $00   ; B
+	dc.b $3C, $66, $C0, $C0, $C0, $66, $3C, $00   ; C
+	dc.b $F8, $6C, $66, $66, $66, $6C, $F8, $00   ; D
+	dc.b $FE, $62, $68, $78, $68, $62, $FE, $00   ; E
+	dc.b $FE, $62, $68, $78, $68, $60, $F0, $00   ; F

--- a/src/minimig-aga/agnus_bitplanedma.v
+++ b/src/minimig-aga/agnus_bitplanedma.v
@@ -66,8 +66,8 @@ wire [ 8: 2] ddfdiff;
 wire [ 8: 2] ddfdiff_masked;
 reg  [15: 1] bpl1mod;             // modulo for odd bitplanes
 reg  [15: 1] bpl2mod;             // modulo for even bitplanes
-wire [15: 1] bpl1mod_bscan;       // modulo for odd bitplanes, adjusted for bitplane scandoubling
-wire [15: 1] bpl2mod_bscan;       // modulo for even bitplanes, adjusted for bitplane scandoubling
+reg [15: 1] bpl1mod_bscan;        // modulo for odd bitplanes, adjusted for bitplane scandoubling - AMR, and extra delay, for RAMJAM: Copperslave.
+reg [15: 1] bpl2mod_bscan;        // modulo for even bitplanes, adjusted for bitplane scandoubling
 
 reg  [ 5: 0] bplcon0;             // bitplane control (SHRES, HIRES and BPU bits)
 reg  [ 5: 0] bplcon0_delayed;     // delayed bplcon0 (compatibility)
@@ -374,13 +374,20 @@ always @ (posedge clk) begin
 end
 
 // softena : software display data fetch window
+
+// AMR - OCS and ECS/AGA behave differently when DDFSTRT == DDFSTOP.
+// On OCS the fetch runs until hard_stop. On ECS/AGA it stops after one complete fetch cycle.
+reg softena_off;
+
 always @ (posedge clk) begin
   if (clk7_en) begin
-    if (hpos[0])
+    if (hpos[0]) begin
       if (soft_start && (ecs || vdiwena && dmaena) && !ddfstrt_sel) // OCS: display can start only when vdiwena condition is true
         softena <= #1 1'b1;
-      else if (soft_stop || !ecs && hard_stop)
+      else if (softena_off || (soft_stop || !ecs && hard_stop))
         softena <= #1 1'b0;
+      softena_off<=soft_stop && soft_start && ecs;  // AMR - ECS / AGA: DDFSTRT==DDFSTOP, disable fetch after one fetch cycle.
+    end
   end
 end
 
@@ -465,8 +472,13 @@ end
 assign dma = (ddfrun) && dmaena_delayed[1] && hpos[0] && (plane[4:0] < {1'b0,bpu[3:0]}) ? 1'b1 : 1'b0;
 
 // adjust BPLxMOD for scandoubling
-assign bpl1mod_bscan = fmode[14] ? ((vdiwstrt[0] ^ vpos[0]) ? bpl2mod : bpl1mod) : bpl1mod;
-assign bpl2mod_bscan = fmode[14] ? ((vdiwstrt[0] ^ vpos[0]) ? bpl2mod : bpl1mod) : bpl2mod;
+// AMR - incorporate a delay too
+always @(posedge clk) begin
+	if (clk7_en && hpos[0]) begin
+		bpl1mod_bscan <= fmode[14] ? ((vdiwstrt[0] ^ vpos[0]) ? bpl2mod : bpl1mod) : bpl1mod;
+		bpl2mod_bscan <= fmode[14] ? ((vdiwstrt[0] ^ vpos[0]) ? bpl2mod : bpl1mod) : bpl2mod;
+	end
+end
 
 // dma pointer arithmetic unit
 always @ (*) begin

--- a/src/minimig-aga/cpu_cache_new.v
+++ b/src/minimig-aga/cpu_cache_new.v
@@ -1,0 +1,718 @@
+// cpu_cache_new.v
+// 2015, rok.krajnc@gmail.com
+// this is a 2-way set-associative cache
+// seperate instruction and data caches
+// write-through, look-through
+// 4kB cache size, 2kB per way
+// whole cache size (I+D) is 8kB
+//
+// ----------------------------------------------------
+//
+// - ChipRAM/ROM fixes
+// - Support up to 256MB address space
+//               (C) 2019 Alexey Melnikov
+//
+//
+
+module cpu_cache_new
+(
+  // system
+  input             clk,            // clock
+  input             rst,            // cache reset
+  input       [3:0] cpu_cache_ctrl, // CPU cache control
+  input             cache_inhibit,  // cache inhibit
+
+  // cpu    
+  input             cpu_cs,         // cpu activity
+  input      [28:1] cpu_adr,        // cpu address
+  input       [1:0] cpu_bs,         // cpu byte selects
+  input             cpu_we,         // cpu write
+  input             cpu_ir,         // cpu instruction read
+  input             cpu_dr,         // cpu data read
+  input      [15:0] cpu_dat_w,      // cpu write data
+  output reg [15:0] cpu_dat_r,      // cpu read data
+  output reg        cpu_ack,        // cpu acknowledge
+
+  // writebuffer
+  output reg        wb_en,          // writebuffer enable
+
+  // sdram
+  input      [15:0] sdr_dat_r,      // sdram read data
+  output reg        sdr_read_req,   // sdram read request from cache
+  input             sdr_read_ack,   // sdram read acknowledge to cache
+
+  // snoop
+  input             snoop_act,      // snoop act (write only - just update existing data in cache)
+  input      [28:1] snoop_adr,      // chip address                      
+  input      [15:0] snoop_dat_w,    // snoop write data
+  input       [1:0] snoop_bs
+);
+
+
+//// internal signals ////
+
+// cache init
+reg           cache_init_done;
+// state
+reg   [3:0] cpu_sm_state;
+reg   [3:0] sdr_sm_state;
+// state signals
+reg         fill;
+reg   [9:0] cpu_sm_adr;
+reg         cpu_sm_itag_we;
+reg         cpu_sm_dtag_we;
+reg         cpu_sm_iram0_we;
+reg         cpu_sm_iram1_we;
+reg         cpu_sm_dram0_we;
+reg         cpu_sm_dram1_we;
+reg   [1:0] cpu_sm_bs;
+reg  [15:0] cpu_sm_mem_dat_w;
+reg  [39:0] cpu_sm_tag_dat_w;
+reg         cpu_sm_id;
+reg         cpu_sm_ilru;
+reg         cpu_sm_dlru;
+reg   [9:0] sdr_sm_adr;
+reg         sdr_sm_itag_we;
+reg         sdr_sm_dtag_we;
+reg         sdr_sm_iram0_we;
+reg         sdr_sm_iram1_we;
+reg         sdr_sm_dram0_we;
+reg         sdr_sm_dram1_we;
+reg  [15:0] sdr_sm_mem_dat_w;
+reg  [39:0] sdr_sm_tag_dat_w;
+reg         sdr_sm_id;
+reg         sdr_sm_ilru;
+reg         sdr_sm_dlru;
+
+// cpu cache control
+reg   [1:0] cc_clr_r;
+wire        cpu_cache_enable;
+wire        cpu_cache_clear;
+reg         cc_en;
+reg         cc_clr;
+// cpu address
+wire  [1:0] cpu_adr_blk;
+wire  [7:0] cpu_adr_idx;
+wire [17:0] cpu_adr_tag;
+// idram0
+wire  [9:0] idram0_cpu_adr;
+wire  [1:0] idram0_cpu_bs;
+wire        idram0_cpu_we;
+wire [15:0] idram0_cpu_dat_w;
+wire [15:0] idram0_cpu_dat_r;
+wire  [9:0] idram0_sdr_adr;
+wire  [1:0] idram0_sdr_bs;
+wire        idram0_sdr_we;
+wire [15:0] idram0_sdr_dat_w;
+wire [15:0] idram0_sdr_dat_r;
+// idram1
+wire  [9:0] idram1_cpu_adr;
+wire  [1:0] idram1_cpu_bs;
+wire        idram1_cpu_we;
+wire [15:0] idram1_cpu_dat_w;
+wire [15:0] idram1_cpu_dat_r;
+wire  [9:0] idram1_sdr_adr;
+wire  [1:0] idram1_sdr_bs;
+wire        idram1_sdr_we;
+wire [15:0] idram1_sdr_dat_w;
+wire [15:0] idram1_sdr_dat_r;
+// ddram0
+wire  [9:0] ddram0_cpu_adr;
+wire  [1:0] ddram0_cpu_bs;
+wire        ddram0_cpu_we;
+wire [15:0] ddram0_cpu_dat_w;
+wire [15:0] ddram0_cpu_dat_r;
+wire  [9:0] ddram0_sdr_adr;
+wire  [1:0] ddram0_sdr_bs;
+wire        ddram0_sdr_we;
+wire [15:0] ddram0_sdr_dat_w;
+wire [15:0] ddram0_sdr_dat_r;
+// ddram1
+wire  [9:0] ddram1_cpu_adr;
+wire  [1:0] ddram1_cpu_bs;
+wire        ddram1_cpu_we;
+wire [15:0] ddram1_cpu_dat_w;
+wire [15:0] ddram1_cpu_dat_r;
+wire  [9:0] ddram1_sdr_adr;
+wire  [1:0] ddram1_sdr_bs;
+wire        ddram1_sdr_we;
+wire [15:0] ddram1_sdr_dat_w;
+wire [15:0] ddram1_sdr_dat_r;
+// itram
+wire  [7:0] itram_cpu_adr;
+wire        itram_cpu_we;
+wire [39:0] itram_cpu_dat_w;
+wire [39:0] itram_cpu_dat_r;
+wire  [7:0] itram_sdr_adr;
+wire        itram_sdr_we;
+wire [39:0] itram_sdr_dat_w;
+wire [39:0] itram_sdr_dat_r;
+wire        itag0_match;
+wire        itag1_match;
+wire        itag_lru;
+wire        itag0_valid;
+wire        itag1_valid;
+wire        sdr_itag0_match;
+wire        sdr_itag1_match;
+wire        sdr_itag0_valid;
+wire        sdr_itag1_valid;
+// dtram
+wire  [7:0] dtram_cpu_adr;
+wire        dtram_cpu_we;
+wire [39:0] dtram_cpu_dat_w;
+wire [39:0] dtram_cpu_dat_r;
+wire  [7:0] dtram_sdr_adr;
+wire        dtram_sdr_we;
+wire [39:0] dtram_sdr_dat_w;
+wire [39:0] dtram_sdr_dat_r;
+wire        dtag0_match;
+wire        dtag1_match;
+wire        dtag_lru;
+wire        dtag0_valid;
+wire        dtag1_valid;
+wire        sdr_dtag0_match;
+wire        sdr_dtag1_match;
+wire        sdr_dtag0_valid;
+wire        sdr_dtag1_valid;
+
+
+//// params ////
+
+// cpu-side state machine
+localparam [3:0]
+	CPU_SM_INIT  = 4'd0,
+	CPU_SM_IDLE  = 4'd1,
+	CPU_SM_WRITE = 4'd2,
+	CPU_SM_WB    = 4'd3,
+	CPU_SM_READ  = 4'd4,
+	CPU_SM_WAIT  = 4'd5,
+	CPU_SM_FILL1 = 4'd6,
+	CPU_SM_FILL2 = 4'd7,
+	CPU_SM_FILL3 = 4'd8,
+	CPU_SM_FILL4 = 4'd9,
+	CPU_SM_FILLW = 4'd10;
+
+// sdram-side state machine
+localparam [3:0]
+	SDR_SM_INIT0 = 4'd0,
+	SDR_SM_INIT1 = 4'd1,
+	SDR_SM_IDLE  = 4'd2,
+	SDR_SM_SNOOP = 4'd3,
+	SDR_SM_FILL  = 4'd4,
+	SDR_SM_FILL1 = 4'd5,
+	SDR_SM_FILL2 = 4'd6,
+	SDR_SM_FILL3 = 4'd7,
+	SDR_SM_WAIT  = 4'd8;
+
+
+//// cpu side ////
+
+// cpu cache control
+always @ (posedge clk) begin
+	if (rst) cc_clr_r <= 2'd0;
+	else if (!cpu_cs) cc_clr_r <= {cc_clr_r[0], cpu_cache_ctrl[3]};
+end
+
+assign cpu_cache_enable = cpu_cache_ctrl[0];
+//assign cpu_cache_freeze = cpu_cache_ctrl[1];
+assign cpu_cache_clear  = cc_clr_r[0] && !cc_clr_r[1];
+
+always @ (posedge clk) begin
+	if (rst) begin
+		cc_en  <= 1'b0;
+		//cc_fr  <= 1'b0;
+		cc_clr <= 1'b0;
+	end else if (!cpu_cs) begin
+		cc_en  <= cpu_cache_enable;
+		//cc_fr  <= cpu_cache_freeze;
+		cc_clr <= cpu_cache_clear;
+	end
+end 
+
+// slice up cpu address
+assign cpu_adr_blk = cpu_adr[2:1];    // cache block address (inside cache row), 2 bits for 4x16 rows
+assign cpu_adr_idx = cpu_adr[10:3];   // cache row address, 8 bits
+assign cpu_adr_tag = cpu_adr[28:11];  // tag, 18 bits
+
+// cpu side state machine
+always @ (posedge clk) begin
+  if (rst) begin
+    fill              <= 1'b0;
+    sdr_read_req      <= 1'b0;
+    wb_en             <= 1'b0;
+    cpu_ack           <= 1'b0;
+    cpu_sm_state      <= CPU_SM_INIT;
+    cpu_sm_itag_we    <= 1'b0;
+    cpu_sm_dtag_we    <= 1'b0;
+    cpu_sm_iram0_we   <= 1'b0;
+    cpu_sm_iram1_we   <= 1'b0;
+    cpu_sm_dram0_we   <= 1'b0;
+    cpu_sm_dram1_we   <= 1'b0;
+    cpu_sm_bs         <= 2'b11;
+  end else begin
+    // default values
+    fill              <= 1'b0;
+    sdr_read_req      <= 1'b0;
+    wb_en             <= 1'b0;
+    cpu_sm_itag_we    <= 1'b0;
+    cpu_sm_dtag_we    <= 1'b0;
+    cpu_sm_iram0_we   <= 1'b0;
+    cpu_sm_iram1_we   <= 1'b0;
+    cpu_sm_dram0_we   <= 1'b0;
+    cpu_sm_dram1_we   <= 1'b0;
+    cpu_sm_bs         <= 2'b11;
+    // state machine
+    case (cpu_sm_state)
+      CPU_SM_INIT : begin
+        // waiting for cache init
+        if (cache_init_done) begin
+          cpu_sm_state <= CPU_SM_IDLE;
+        end else begin
+          cpu_sm_state <= CPU_SM_INIT;
+        end
+      end
+      CPU_SM_IDLE : begin
+        // waiting for CPU access
+        if (cpu_cs) begin
+          if (cpu_we) begin
+            cpu_sm_state <= CPU_SM_WRITE;
+          end else begin
+            cpu_sm_state <= CPU_SM_READ;
+          end
+        end else begin
+          if (cc_clr)
+            cpu_sm_state <= CPU_SM_INIT;
+          else
+            cpu_sm_state <= CPU_SM_IDLE;
+        end
+      end
+      CPU_SM_WRITE : begin
+        // on hit update cache, on miss no update neccessary; tags don't get updated on writes
+        cpu_sm_bs <= cpu_bs;
+        cpu_sm_mem_dat_w <= cpu_dat_w;
+        cpu_sm_iram0_we <= itag0_match && itag0_valid /*&& !cc_fr*/;
+        cpu_sm_iram1_we <= itag1_match && itag1_valid /*&& !cc_fr*/;
+        cpu_sm_dram0_we <= dtag0_match && dtag0_valid /*&& !cc_fr*/;
+        cpu_sm_dram1_we <= dtag1_match && dtag1_valid /*&& !cc_fr*/;
+        cpu_sm_state <= CPU_SM_WB;
+        wb_en <= 1'b1;
+        if (!cpu_cs) cpu_sm_state <= CPU_SM_IDLE;
+      end
+      CPU_SM_WB : begin
+        if (!cpu_cs) cpu_sm_state <= CPU_SM_IDLE;
+        else wb_en <= 1'b1;
+      end
+      CPU_SM_READ : begin
+        // on hit update LRU flag in tag memory
+        if (cc_en && itag0_match && itag0_valid) begin
+          // data is already in instruction cache way 0
+          cpu_dat_r <= idram0_cpu_dat_r;
+          cpu_ack <= 1'b1;
+          cpu_sm_itag_we <= 1'b1;
+          cpu_sm_tag_dat_w <= {1'b0, itram_cpu_dat_r[38:0]};
+          cpu_sm_state <= CPU_SM_WAIT;
+        end else if (cc_en && itag1_match && itag1_valid) begin
+          // data is already in instruction cache way 1
+          cpu_dat_r <= idram1_cpu_dat_r;
+          cpu_ack <= 1'b1;
+          cpu_sm_itag_we <= 1'b1;
+          cpu_sm_tag_dat_w <= {1'b1, itram_cpu_dat_r[38:0]};
+          cpu_sm_state <= CPU_SM_WAIT;
+        end else if (cc_en && dtag0_match && dtag0_valid) begin
+          // data is already in data cache way 0
+          cpu_dat_r <= ddram0_cpu_dat_r;
+          cpu_ack <= 1'b1;
+          cpu_sm_dtag_we <= 1'b1;
+          cpu_sm_tag_dat_w <= {1'b0, dtram_cpu_dat_r[38:0]};
+          cpu_sm_state <= CPU_SM_WAIT;
+        end else if (cc_en && dtag1_match && dtag1_valid) begin
+          // data is already in data cache way 1
+          cpu_dat_r <= ddram1_cpu_dat_r;
+          cpu_ack <= 1'b1;
+          cpu_sm_dtag_we <= 1'b1;
+          cpu_sm_tag_dat_w <= {1'b1, dtram_cpu_dat_r[38:0]};
+          cpu_sm_state <= CPU_SM_WAIT;
+        end else begin
+          // on miss fetch data from SDRAM
+          sdr_read_req <= 1'b1;
+          cpu_sm_state <= CPU_SM_FILL1;
+        end
+      end
+      CPU_SM_WAIT : begin
+        if (!cpu_cs) cpu_sm_state <= CPU_SM_IDLE;
+      end
+      CPU_SM_FILL1 : begin
+        fill <= 1'b1;
+        cpu_sm_adr <= cpu_adr[10:1]; 
+        if (!sdr_read_ack) begin
+          sdr_read_req <= 1'b1;
+        end else begin
+          sdr_read_req <= 1'b0;
+          // read data to cpu
+          cpu_dat_r <= sdr_dat_r;
+          cpu_ack <= 1'b1;
+          if (cache_inhibit) begin
+            // don't update cache if caching is inhibited
+            cpu_sm_state <= CPU_SM_FILLW;
+          end else begin      
+            // update tag ram
+            if (cpu_ir) begin
+              if (itag_lru) begin
+                cpu_sm_tag_dat_w <= {1'b0, 1'b1, itram_cpu_dat_r[37], 1'b0, itram_cpu_dat_r[35:18], cpu_adr_tag};
+              end else begin
+                cpu_sm_tag_dat_w <= {1'b1, itram_cpu_dat_r[38], 1'b1, 1'b0, cpu_adr_tag, itram_cpu_dat_r[17: 0]};
+              end
+            end else begin
+              if (dtag_lru) begin
+                cpu_sm_tag_dat_w <= {1'b0, 1'b1, dtram_cpu_dat_r[37], 1'b0, dtram_cpu_dat_r[35:18], cpu_adr_tag};
+              end else begin
+                cpu_sm_tag_dat_w <= {1'b1, dtram_cpu_dat_r[38], 1'b1, 1'b0, cpu_adr_tag, dtram_cpu_dat_r[17: 0]};
+              end
+            end
+            cpu_sm_itag_we <=  cpu_ir;
+            cpu_sm_dtag_we <= !cpu_ir;
+            // cache line fill 1st word
+            cpu_sm_id   <= cpu_ir;
+            cpu_sm_ilru <= itag_lru;
+            cpu_sm_dlru <= dtag_lru;
+            cpu_sm_mem_dat_w <= sdr_dat_r;
+            cpu_sm_iram0_we <=  itag_lru &&  cpu_ir;
+            cpu_sm_iram1_we <= !itag_lru &&  cpu_ir;
+            cpu_sm_dram0_we <=  dtag_lru && !cpu_ir;
+            cpu_sm_dram1_we <= !dtag_lru && !cpu_ir;
+            cpu_sm_state <= CPU_SM_FILL2;
+          end
+        end
+      end
+      CPU_SM_FILL2 : begin
+        if (sdr_read_ack) begin
+			  // cache line fill 2nd word
+			  fill <= 1'b1;
+			  cpu_sm_adr[1:0] <= cpu_sm_adr[1:0] + 2'b01;
+			  cpu_sm_mem_dat_w <= sdr_dat_r;
+			  cpu_sm_iram0_we <=  cpu_sm_ilru &&  cpu_sm_id;
+			  cpu_sm_iram1_we <= !cpu_sm_ilru &&  cpu_sm_id;
+			  cpu_sm_dram0_we <=  cpu_sm_dlru && !cpu_sm_id;
+			  cpu_sm_dram1_we <= !cpu_sm_dlru && !cpu_sm_id;
+			  cpu_sm_state <= CPU_SM_FILL3;
+        end
+      end
+      CPU_SM_FILL3 : begin
+        if (sdr_read_ack) begin
+			  // cache line fill 3rd word
+			  fill <= 1'b1;
+			  cpu_sm_adr[1:0] <= cpu_sm_adr[1:0] + 2'b01;
+			  cpu_sm_mem_dat_w <= sdr_dat_r;
+			  cpu_sm_iram0_we <=  cpu_sm_ilru &&  cpu_sm_id;
+			  cpu_sm_iram1_we <= !cpu_sm_ilru &&  cpu_sm_id;
+			  cpu_sm_dram0_we <=  cpu_sm_dlru && !cpu_sm_id;
+			  cpu_sm_dram1_we <= !cpu_sm_dlru && !cpu_sm_id;
+			  cpu_sm_state <= CPU_SM_FILL4;
+        end
+      end
+      CPU_SM_FILL4 : begin
+        if (sdr_read_ack) begin
+			  // cache line fill 4th word
+			  fill <= 1'b1;
+			  cpu_sm_adr[1:0] <= cpu_sm_adr[1:0] + 2'b01;
+			  cpu_sm_mem_dat_w <= sdr_dat_r;
+			  cpu_sm_iram0_we <=  cpu_sm_ilru &&  cpu_sm_id;
+			  cpu_sm_iram1_we <= !cpu_sm_ilru &&  cpu_sm_id;
+			  cpu_sm_dram0_we <=  cpu_sm_dlru && !cpu_sm_id;
+			  cpu_sm_dram1_we <= !cpu_sm_dlru && !cpu_sm_id;
+			  cpu_sm_state <= CPU_SM_FILLW;
+			  //if (!cpu_ack) cpu_sm_state <= CPU_SM_IDLE;
+        end
+      end
+      CPU_SM_FILLW : begin
+        if (!cpu_ack) begin
+          cpu_sm_state <= CPU_SM_IDLE;
+        end
+      end
+    endcase
+    // when CPU lowers its request signal, lower ack too
+    if (!cpu_cs) cpu_ack <= 1'b0;
+  end
+end
+
+
+//// sdram side ////
+
+// sdram side state machine
+always @ (posedge clk) begin
+  if (rst) begin
+    cache_init_done   <= 1'b0;
+    sdr_sm_state      <= SDR_SM_INIT0;
+    sdr_sm_itag_we    <= 1'b0;
+    sdr_sm_dtag_we    <= 1'b0;
+    sdr_sm_iram0_we   <= 1'b0;
+    sdr_sm_iram1_we   <= 1'b0;
+    sdr_sm_dram0_we   <= 1'b0;
+    sdr_sm_dram1_we   <= 1'b0;
+  end else begin
+    // default values
+    cache_init_done   <= 1'b1;
+    sdr_sm_itag_we    <= 1'b0;
+    sdr_sm_dtag_we    <= 1'b0;
+    sdr_sm_iram0_we   <= 1'b0;
+    sdr_sm_iram1_we   <= 1'b0;
+    sdr_sm_dram0_we   <= 1'b0;
+    sdr_sm_dram1_we   <= 1'b0;
+    // state machine
+    case (sdr_sm_state)
+      SDR_SM_INIT0 : begin
+        // prepare to clear cache
+        cache_init_done <= 1'b0;
+        sdr_sm_adr <= 10'd0;
+        sdr_sm_tag_dat_w <= 40'd0;
+        sdr_sm_itag_we <= 1'b1;
+        sdr_sm_dtag_we <= 1'b1;
+        sdr_sm_state <= SDR_SM_INIT1;
+      end
+      SDR_SM_INIT1 : begin
+        // clear cache
+        cache_init_done <= 1'b0;
+        sdr_sm_adr <= sdr_sm_adr + 10'd4;
+        sdr_sm_itag_we <= 1'b1;
+        sdr_sm_dtag_we <= 1'b1;
+        if (&sdr_sm_adr[9:2]) begin
+          sdr_sm_state <= SDR_SM_IDLE;
+        end else begin
+          sdr_sm_state <= SDR_SM_INIT1;
+        end
+      end
+      SDR_SM_IDLE : begin
+        // wait for action
+        cache_init_done <= 1'b1;
+        sdr_sm_adr <= snoop_adr[10:1];
+        if (cc_clr) begin
+          sdr_sm_state <= SDR_SM_INIT0;
+        end
+        else if (snoop_act) begin
+          // chip write happening
+          sdr_sm_state <= SDR_SM_WAIT;
+        end
+      end
+      SDR_SM_WAIT : begin
+        sdr_sm_state <= SDR_SM_SNOOP;
+		end
+      SDR_SM_SNOOP : begin
+        // update if a matching address is in cache
+        sdr_sm_mem_dat_w <= snoop_dat_w;
+        sdr_sm_iram0_we <= sdr_itag0_match && sdr_itag0_valid;
+        sdr_sm_iram1_we <= sdr_itag1_match && sdr_itag1_valid;
+        sdr_sm_dram0_we <= sdr_dtag0_match && sdr_dtag0_valid;
+        sdr_sm_dram1_we <= sdr_dtag1_match && sdr_dtag1_valid;
+        sdr_sm_state <= SDR_SM_IDLE;
+      end
+    endcase
+  end
+end
+
+
+//// instruction memories ////
+
+// instruction tag ram
+assign itram_cpu_adr    = cpu_adr_idx;
+assign itram_cpu_we     = cpu_sm_itag_we;
+assign itram_cpu_dat_w  = cpu_sm_tag_dat_w;
+assign itag0_match      = (cpu_adr_tag == itram_cpu_dat_r[17:0]);
+assign itag1_match      = (cpu_adr_tag == itram_cpu_dat_r[35:18]);
+assign itag_lru         = itram_cpu_dat_r[39];
+assign itag0_valid      = itram_cpu_dat_r[38];
+assign itag1_valid      = itram_cpu_dat_r[37];
+assign itram_sdr_adr    = sdr_sm_adr[9:2];
+assign itram_sdr_we     = sdr_sm_itag_we;
+assign itram_sdr_dat_w  = sdr_sm_tag_dat_w;
+assign sdr_itag0_match  = (snoop_adr[28:11] == itram_sdr_dat_r[17:0]);
+assign sdr_itag1_match  = (snoop_adr[28:11] == itram_sdr_dat_r[35:18]);
+assign sdr_itag0_valid  = itram_sdr_dat_r[38];
+assign sdr_itag1_valid  = itram_sdr_dat_r[37];
+
+dpram #(8,40) itram (
+  .clock      (clk              ),
+  .address_a  (itram_cpu_adr    ),
+  .wren_a     (itram_cpu_we     ),
+  .data_a     (itram_cpu_dat_w  ),
+  .q_a        (itram_cpu_dat_r  ),
+  .address_b  (itram_sdr_adr    ),
+  .wren_b     (itram_sdr_we     ),
+  .data_b     (itram_sdr_dat_w  ),
+  .q_b        (itram_sdr_dat_r  )
+);
+
+// instruction data ram 0
+assign idram0_cpu_adr   = fill ? cpu_sm_adr : {cpu_adr_idx, cpu_adr_blk};
+assign idram0_cpu_bs    = cpu_sm_bs;
+assign idram0_cpu_we    = cpu_sm_iram0_we;
+assign idram0_cpu_dat_w = cpu_sm_mem_dat_w;
+assign idram0_sdr_adr   = snoop_adr[10:1];
+assign idram0_sdr_bs    = snoop_bs;
+assign idram0_sdr_we    = sdr_sm_iram0_we;
+assign idram0_sdr_dat_w = sdr_sm_mem_dat_w;
+
+dpram_be_1024x16 idram0 (
+  .clock      (clk              ),
+  .address_a  (idram0_cpu_adr   ),
+  .byteena_a  (idram0_cpu_bs    ),
+  .wren_a     (idram0_cpu_we    ),
+  .data_a     (idram0_cpu_dat_w ),
+  .q_a        (idram0_cpu_dat_r ),
+  .address_b  (idram0_sdr_adr   ),
+  .byteena_b  (idram0_sdr_bs    ),
+  .wren_b     (idram0_sdr_we    ),
+  .data_b     (idram0_sdr_dat_w ),
+  .q_b        (idram0_sdr_dat_r )
+);
+
+// instruction data ram 1
+assign idram1_cpu_adr   = fill ? cpu_sm_adr : {cpu_adr_idx, cpu_adr_blk};
+assign idram1_cpu_bs    = cpu_sm_bs;
+assign idram1_cpu_we    = cpu_sm_iram1_we;
+assign idram1_cpu_dat_w = cpu_sm_mem_dat_w;
+assign idram1_sdr_adr   = snoop_adr[10:1];
+assign idram1_sdr_bs    = snoop_bs;
+assign idram1_sdr_we    = sdr_sm_iram1_we;
+assign idram1_sdr_dat_w = sdr_sm_mem_dat_w;
+
+dpram_be_1024x16 idram1 (
+  .clock      (clk              ),
+  .address_a  (idram1_cpu_adr   ),
+  .byteena_a  (idram1_cpu_bs    ),
+  .wren_a     (idram1_cpu_we    ),
+  .data_a     (idram1_cpu_dat_w ),
+  .q_a        (idram1_cpu_dat_r ),
+  .address_b  (idram1_sdr_adr   ),
+  .byteena_b  (idram1_sdr_bs    ),
+  .wren_b     (idram1_sdr_we    ),
+  .data_b     (idram1_sdr_dat_w ),
+  .q_b        (idram1_sdr_dat_r )
+);
+
+
+//// data data memories ////
+
+// data tag ram
+assign dtram_cpu_adr    = cpu_adr_idx;
+assign dtram_cpu_we     = cpu_sm_dtag_we;
+assign dtram_cpu_dat_w  = cpu_sm_tag_dat_w;
+assign dtag0_match      = (cpu_adr_tag == dtram_cpu_dat_r[17:0]);
+assign dtag1_match      = (cpu_adr_tag == dtram_cpu_dat_r[35:18]);
+assign dtag_lru         = dtram_cpu_dat_r[39];
+assign dtag0_valid      = dtram_cpu_dat_r[38];
+assign dtag1_valid      = dtram_cpu_dat_r[37];
+assign dtram_sdr_adr    = sdr_sm_adr[9:2];
+assign dtram_sdr_we     = sdr_sm_dtag_we;
+assign dtram_sdr_dat_w  = sdr_sm_tag_dat_w;
+assign sdr_dtag0_match  = (snoop_adr[28:11] == dtram_sdr_dat_r[17:0]);
+assign sdr_dtag1_match  = (snoop_adr[28:11] == dtram_sdr_dat_r[35:18]);
+assign sdr_dtag0_valid  = dtram_sdr_dat_r[38];
+assign sdr_dtag1_valid  = dtram_sdr_dat_r[37];
+
+dpram #(8,40) dtram (
+  .clock      (clk              ),
+  .address_a  (dtram_cpu_adr    ),
+  .wren_a     (dtram_cpu_we     ),
+  .data_a     (dtram_cpu_dat_w  ),
+  .q_a        (dtram_cpu_dat_r  ),
+  .address_b  (dtram_sdr_adr    ),
+  .wren_b     (dtram_sdr_we     ),
+  .data_b     (dtram_sdr_dat_w  ),
+  .q_b        (dtram_sdr_dat_r  )
+);
+
+// data data ram 0
+assign ddram0_cpu_adr   = fill ? cpu_sm_adr : {cpu_adr_idx, cpu_adr_blk};
+assign ddram0_cpu_bs    = cpu_sm_bs;
+assign ddram0_cpu_we    = cpu_sm_dram0_we;
+assign ddram0_cpu_dat_w = cpu_sm_mem_dat_w;
+assign ddram0_sdr_adr   = snoop_adr[10:1];
+assign ddram0_sdr_bs    = snoop_bs;
+assign ddram0_sdr_we    = sdr_sm_dram0_we;
+assign ddram0_sdr_dat_w = sdr_sm_mem_dat_w;
+
+dpram_be_1024x16 ddram0 (
+  .clock      (clk              ),
+  .address_a  (ddram0_cpu_adr   ),
+  .byteena_a  (ddram0_cpu_bs    ),
+  .wren_a     (ddram0_cpu_we    ),
+  .data_a     (ddram0_cpu_dat_w ),
+  .q_a        (ddram0_cpu_dat_r ),
+  .address_b  (ddram0_sdr_adr   ),
+  .byteena_b  (ddram0_sdr_bs    ),
+  .wren_b     (ddram0_sdr_we    ),
+  .data_b     (ddram0_sdr_dat_w ),
+  .q_b        (ddram0_sdr_dat_r )
+);
+
+// data data ram 1
+assign ddram1_cpu_adr   = fill ? cpu_sm_adr : {cpu_adr_idx, cpu_adr_blk};
+assign ddram1_cpu_bs    = cpu_sm_bs;
+assign ddram1_cpu_we    = cpu_sm_dram1_we;
+assign ddram1_cpu_dat_w = cpu_sm_mem_dat_w;
+assign ddram1_sdr_adr   = snoop_adr[10:1];
+assign ddram1_sdr_bs    = snoop_bs;
+assign ddram1_sdr_we    = sdr_sm_dram1_we;
+assign ddram1_sdr_dat_w = sdr_sm_mem_dat_w;
+
+dpram_be_1024x16 ddram1 (
+  .clock      (clk              ),
+  .address_a  (ddram1_cpu_adr   ),
+  .byteena_a  (ddram1_cpu_bs    ),
+  .wren_a     (ddram1_cpu_we    ),
+  .data_a     (ddram1_cpu_dat_w ),
+  .q_a        (ddram1_cpu_dat_r ),
+  .address_b  (ddram1_sdr_adr   ),
+  .byteena_b  (ddram1_sdr_bs    ),
+  .wren_b     (ddram1_sdr_we    ),
+  .data_b     (ddram1_sdr_dat_w ),
+  .q_b        (ddram1_sdr_dat_r )
+);
+
+endmodule
+
+
+module dpram_be_1024x16
+(
+	input         clock,
+
+	input	  [9:0] address_a,
+	input	  [1:0] byteena_a,
+	input	 [15:0] data_a,
+	input         wren_a,
+	output [15:0] q_a,
+
+	input	  [9:0] address_b,
+	input	  [1:0] byteena_b,
+	input	 [15:0] data_b,
+	input	        wren_b,
+	output [15:0] q_b
+);
+
+dpram #(10,8) ram_l
+(
+	.clock(clock),
+	.address_a(address_a),
+	.data_a(data_a[7:0]),
+	.wren_a(byteena_a[0] & wren_a),
+	.q_a(q_a[7:0]),
+	.address_b(address_b),
+	.data_b(data_b[7:0]),
+	.wren_b(byteena_b[0] & wren_b),
+	.q_b(q_b[7:0])
+);
+
+dpram #(10,8) ram_u
+(
+	.clock(clock),
+	.address_a(address_a),
+	.data_a(data_a[15:8]),
+	.wren_a(byteena_a[1] & wren_a),
+	.q_a(q_a[15:8]),
+	.address_b(address_b),
+	.data_b(data_b[15:8]),
+	.wren_b(byteena_b[1] & wren_b),
+	.q_b(q_b[15:8])
+);
+
+endmodule

--- a/src/minimig-aga/cpu_wrapper.v
+++ b/src/minimig-aga/cpu_wrapper.v
@@ -88,7 +88,8 @@ module cpu_wrapper
 
 	output reg  [1:0] cpustate,
 	output reg  [3:0] cacr,
-	output reg [31:0] nmi_addr
+	output reg [31:0] nmi_addr,
+	output            cpu_clkena  // the tg68k advances on this enable (bus handshake consumption)
 );
 
 wire cpu_req = cpustate != 1 && !skip_fetch;
@@ -124,9 +125,14 @@ wire sel_dd     = (cpu_addr[31:16] == 16'h00DD) && (cpu_addr[15:13] == 'b010);
 wire sel_rtg    = (cpu_addr[31:24] == 8'h02);
 
 // don't sel_kickram when writing
-wire	cchip;
-wire	ckick;
-wire sel_kickram   = !cpu_addr[31:24] && (&cpu_addr[23:19] || (cpu_addr[23:19] == 5'b11100)) && ckick && wr;	// $f8xxxx, e0xxxx
+wire	cchip;   
+wire	ckick;   
+// NanoMig: only the real $f8xxxx kickstart range is served from sdram in
+// turbo kick mode. The $e0xxxx extended rom area of the MiSTer mapping is
+// NOT initialized in sdram here, so those reads must keep going to the
+// chip bus (which returns zeros = no extension rom) instead of reading
+// random uninitialized sdram content.
+wire sel_kickram   = !cpu_addr[31:24] && (&cpu_addr[23:19]) && ckick && wr;	// $f8xxxx
 wire sel_kicklower = !cpu_addr[31:24] && (cpu_addr[23:18] == 6'b111110);
 wire sel_chipram   = !cpu_addr[31:21] && cchip; 		             //$000000 - $1FFFFF
 
@@ -290,14 +296,35 @@ wire        longword;
 reg [2:0]   cpu_ipl;
 reg         chipready;
 
+// tg68_armed keeps the cpu from being clocked before the reset has been
+// released for at least one cycle, otherwise the TG68K can hang on startup
+reg  tg68_armed;
+always @(posedge clk) tg68_armed <= reset;
+
+`ifdef CPU_SLOW14
+// Advance the TG68K at most every second clk cycle (14MHz effective on a
+// 28MHz clock, matching the 14MHz 68EC020 of a real A1200). This makes all
+// TG68K internal register-to-register paths true two-cycle paths which is
+// required for timing closure on slow devices. The single cycle ready
+// strobes of the bus interfaces are latched so no handshake is ever lost.
+// Instead of a fixed phase enable only a minimum gap of one idle cycle
+// after every advance is enforced, so memory handshakes are consumed at
+// the earliest opportunity and no average alignment latency is added.
+reg  gap;       // previous clk cycle advanced the cpu
+reg  readyhold;
+wire ready_now = chipready | ramready | fastchip_ready;
+wire clkena_slow = ~gap & ((~cpu_req & tg68_armed) | ready_now | readyhold);
+assign cpu_clkena = clkena_slow;
+always @(posedge clk) begin
+	gap <= clkena_slow;
+	if (clkena_slow)               readyhold <= 1'b0;
+	else if (ready_now & cpu_req)  readyhold <= 1'b1;
+end
+`else
+assign cpu_clkena = (~cpu_req & tg68_armed) | chipready | ramready | fastchip_ready;
+`endif
+
 `ifdef ENABLE_TG68K
-
-reg tg68_armed;
-
-always @(posedge clk)
-    tg68_armed <= reset;
-
-
 TG68KdotC_Kernel
 `ifndef VERILATOR
 // verilator runs the verilog translated variant which doesn't support configuration but
@@ -314,13 +341,35 @@ TG68KdotC_Kernel
 `endif
 cpu_inst_p
 (
+`ifdef VERILATOR
+  // the verilog translation of the kernel used for simulation has
+  // all-lowercase port names
   .clk(clk),
-`ifdef ENABLE_FX68K
-  .nReset(reset && cpucfg[1]),
+  .nreset(reset),
+  .clkena_in(cpu_clkena),
+  .data_in(cpu_din),
+  .ipl(cpu_ipl),
+  .ipl_autovector(1),
+  .regin_out(),
+  .addr_out(cpu_addr_p),
+  .data_write(cpu_dout_p),
+  .nwr(wr_p),
+  .nuds(uds_p),
+  .nlds(lds_p),
+  .nresetout(reset_out_p),
+  .longword(longword),
+  .cpu(cpucfg),
+  .busstate(cpustate_p),		// 0: fetch code, 1: no memaccess, 2: read data, 3: write data
+  .cacr_out(cacr_p),
+  .vbr_out(vbr_p)
 `else
+  .clk(clk),
+ `ifdef ENABLE_FX68K
+  .nReset(reset && cpucfg[1]),
+ `else
   .nReset(reset),
-`endif
-  .clkena_in((~cpu_req && tg68_armed) | chipready | ramready | fastchip_ready),
+ `endif
+  .clkena_in(cpu_clkena),
   .data_in(cpu_din),
   .IPL(cpu_ipl),
   .IPL_autovector(1'b1),
@@ -340,6 +389,7 @@ cpu_inst_p
   .regin_out(),
   .CACR_out(cacr_p),
   .VBR_out(vbr_p)
+`endif
 );
 `endif
 

--- a/src/minimig-aga/dpram.v
+++ b/src/minimig-aga/dpram.v
@@ -1,0 +1,43 @@
+// dpram.v
+//
+// Generic true dual port ram with synchronous (registered) reads on both
+// ports, replacing the altera_mf based bram.vhd of Minimig-AGA_MiSTer for
+// the cpu cache. Both ports may write. The read data register keeps its
+// value during a write on the same port ("normal" write mode of the Gowin
+// DPB block ram, which is the template Gowin's synthesis infers). The cache
+// never reads and writes through the same port in the same cycle.
+
+module dpram #(
+	parameter addr_width = 8,
+	parameter data_width = 8
+) (
+	input                       clock,
+
+	input      [addr_width-1:0] address_a,
+	input      [data_width-1:0] data_a,
+	input                       wren_a,
+	output reg [data_width-1:0] q_a,
+
+	input      [addr_width-1:0] address_b,
+	input      [data_width-1:0] data_b,
+	input                       wren_b,
+	output reg [data_width-1:0] q_b
+);
+
+reg [data_width-1:0] mem [0:(1<<addr_width)-1];
+
+always @(posedge clock) begin
+	if (wren_a)
+		mem[address_a] <= data_a;
+	else
+		q_a <= mem[address_a];
+end
+
+always @(posedge clock) begin
+	if (wren_b)
+		mem[address_b] <= data_b;
+	else
+		q_b <= mem[address_b];
+end
+
+endmodule

--- a/src/misc/amiga.xml
+++ b/src/misc/amiga.xml
@@ -56,7 +56,7 @@
 	<listentry label="OCS-A500" value="0"/>
 	<listentry label="OCS-A1000" value="1"/>
 	<listentry label="ECS" value="2"/>
-	<!--IS mistle_gw5a_25 -->
+	<!--IS mistle_gw5a_25 tang_nano20k_020 -->
 	<listentry label="AGA" value="3"/>
 	<!--END-->
       </list>

--- a/src/misc/sdram.sv
+++ b/src/misc/sdram.sv
@@ -85,6 +85,7 @@ module sdram #(
   // cpu interface
   input  wire [15:0] p2_din,   // data input from cpu
   output reg  [15:0] p2_dout,  // data output to cpu
+  output reg  [47:0] p2_dout48, // upper 48 bits of a 64 bit aligned cpu read
 
   input  wire [22:0] p2_addr,  // 23 bit word address
   input  wire  [1:0] p2_ds,    // upper/lower data strobe
@@ -412,6 +413,7 @@ generate
         STATE_READ_0: begin
           case (sdram_port)
             PORT_1: dout48[47:32] <= ram_dout_lo;
+            PORT_2: p2_dout48[47:32] <= ram_dout_lo;
             default: ;
           endcase
         end
@@ -423,6 +425,12 @@ generate
               else
                 dout48[31: 0] <= {ram_dout_hi, ram_dout_lo};
             end
+            PORT_2: begin
+              if (addr_0)
+                p2_dout48[47:16] <= {ram_dout_hi, ram_dout_lo};
+              else
+                p2_dout48[31: 0] <= {ram_dout_hi, ram_dout_lo};
+            end
             default: ;
           endcase
         end
@@ -431,6 +439,12 @@ generate
             PORT_1: begin
               if (addr_0)
                 dout48[15:0] <= {ram_dout_hi};
+              else
+                /* no-op */;
+            end
+            PORT_2: begin
+              if (addr_0)
+                p2_dout48[15:0] <= {ram_dout_hi};
               else
                 /* no-op */;
             end
@@ -456,18 +470,21 @@ generate
         STATE_READ_1: begin
           case (sdram_port)
             PORT_1: dout48[47:32] <= ram_dout;
+            PORT_2: p2_dout48[47:32] <= ram_dout;
             default: ;
           endcase
         end
         STATE_READ_2: begin
           case (sdram_port)
             PORT_1: dout48[31:16] <= ram_dout;
+            PORT_2: p2_dout48[31:16] <= ram_dout;
             default: ;
           endcase
         end
         STATE_READ_3: begin
           case (sdram_port)
             PORT_1: dout48[15: 0] <= ram_dout;
+            PORT_2: p2_dout48[15: 0] <= ram_dout;
             default: ;
           endcase
         end

--- a/src/nanomig.v
+++ b/src/nanomig.v
@@ -90,6 +90,7 @@ module nanomig (
    output	 fastram_lds,
    output	 fastram_uds,
    input [15:0]	 fastram_dout,
+   input [47:0]	 fastram_chip48, // upper 48 bits of a 64 bit aligned read (cache line fill)
    output [15:0] fastram_din,
    output	 fastram_wr,
    input	 fastram_ready
@@ -184,6 +185,7 @@ always @(*) begin
 end
 
 wire  [1:0] cpu_state;
+wire        cpu_clkena;
 // wire        cpu_nrst_out;
 wire  [3:0] cpu_cacr;
 wire [31:0] cpu_nmi_addr;
@@ -204,7 +206,25 @@ wire [1:0] cpucfg = cpu_config; // CPU-Type: 00 = 68000, 01 = 68010, 11 = 68020
 
 // cache bits: dcache, kick, chip
 // wire [2:0] cachecfg = { 1'b0, ~ovl, 1'b0 };
-wire [2:0] cachecfg = 3'b000;  // no turbo chip and kick, no caches   
+`ifdef ENABLE_CACHE
+ `ifdef CHIPRAM_CACHE
+// chip ram is cached as well. Instruction fetches only (dcache bit clear),
+// which mirrors the 68EC020 of a real A1200: it has an instruction cache but
+// no data cache, so loops run from the cache while all data accesses keep
+// their original chip bus timing. Chip bus writes are snooped so cached
+// lines stay coherent with blitter/copper/cpu writes.
+// turbo chip must be off while the kickstart overlay maps the rom to
+// $000000, otherwise instruction fetches would read chip ram instead of
+// the rom. cpu_wrapper only samples these bits between bus cycles.
+wire [2:0] cachecfg = { 1'b1, 1'b1, ~ovl };  // data cache, turbo kick, turbo chip when no overlay
+ `else
+wire [2:0] cachecfg = 3'b110;  // data cache + turbo kick (cached kickstart via the direct ram path), chip accesses stay on the chip bus
+ `endif
+`elsif TURBO_KICK
+wire [2:0] cachecfg = 3'b010;  // turbo kick only, no cache: kick reads use the plain direct ram path
+`else
+wire [2:0] cachecfg = 3'b000;  // no turbo chip and kick, no caches
+`endif
 // wire [2:0] cachecfg = 3'b010;  // permanent turbo kick
 
 wire	   pwr_led_bright;
@@ -234,8 +254,20 @@ wire [28:1] ram_addr;
 wire	    ram_sel;
 wire	    ram_lds;
 wire	    ram_uds;
-wire	    ram_ready;
+   
+// ram_ready finally is the clkena for the tg68k
+`ifdef ENABLE_CACHE
+// ram_ready follows the cache acknowledge level directly instead of being
+// re-registered: cache_cs drops in the same cycle (see cache_cs below), which
+// makes the cache clear its ack, so this stays a single cycle pulse but
+// arrives one clock earlier - on every single cpu memory access.
+reg         ram_write_ready;   // write accepted into the write buffer
+wire        ram_ready = cache_ack | ram_write_ready;
+`else
+reg	    ram_ready;
+`endif
 
+`ifndef ENABLE_CACHE
 reg fastram_ready_d;
 
 // cpu_ph1 is just before clk7_en, so this is
@@ -253,6 +285,7 @@ always @(posedge clk_sys) begin
   if (!cpu_rst || cpu_ph1)
     fastram_ready_d <= fastram_ready;
 end
+`endif
 
 cpu_wrapper cpu_wrapper
 (
@@ -298,16 +331,259 @@ cpu_wrapper cpu_wrapper
 
 	//custom CPU signals
 	.cpustate     (cpu_state       ),
+	.cpu_clkena   (cpu_clkena      ),
 	.cacr         (cpu_cacr        ),
 	.nmi_addr     (cpu_nmi_addr    )
 );
+   
+`ifdef ENABLE_CACHE
+// ----------------------- cpu cache (MiSTer cpu_cache_new) -----------------------
+// The cache sits between the cpu's direct ram path and the sdram. Reads are
+// served from the cache on a hit, a miss fetches a full 64 bit line from the
+// sdram (critical word first). Writes are write-through with a one entry
+// write buffer, the cpu is acknowledged as soon as the cache accepted the
+// write. All chip bus writes (cpu or dma) are snooped to keep cached
+// chip ram / kickstart data coherent.
+// A chip bus write updates memory behind the cache's back (blitter, copper,
+// disk dma or - with the data cache disabled - the cpu itself). Pulse the
+// snoop port at the start of every such write; address and data stay valid
+// for the whole 7MHz bus cycle, which covers the three clk_sys cycles the
+// snoop state machine needs to look up and update the cached copy.
+`ifdef CHIPRAM_CACHE
+// Chip bus writes have to reach the cache or freshly loaded code keeps
+// executing from stale cache lines. Two problems have to be solved:
+//   - the write strobe is only asserted for about two of the four clocks of a
+//     7MHz bus cycle, while the cache samples the snoop address and data three
+//     clocks after being told about the write, so the live bus signals would
+//     hand it the following access instead,
+//   - the cache needs three clocks per snoop while the chip bus can deliver a
+//     write every four, so a write arriving while the snoop machine is still
+//     busy would be dropped silently.
+// Writes are therefore queued and handed over at a fixed one-per-four-clocks
+// pace, with address, data and byte selects held stable until the cache has
+// consumed them.
+reg         ram_we_n_d;
+reg  [22:1] snoop_adr_r;
+reg  [15:0] snoop_dat_r;
+reg  [1:0]  snoop_bs_r;
+reg         snoop_act;
 
+// two entries are enough: the chip bus delivers a write at most every four
+// clocks and one is handed over every four, so the queue only has to absorb
+// the case where a write arrives while the previous one is still being passed
+reg  [22:1] sq_adr [0:1];
+reg  [15:0] sq_dat [0:1];
+reg  [1:0]  sq_bs  [0:1];
+reg  [1:0]  sq_wr, sq_rd;
+reg  [1:0]  sq_pace;
+wire        sq_empty = (sq_wr == sq_rd);
+wire        sq_full  = ((sq_wr - sq_rd) == 2'd2);
+wire        sq_push  = ram_we_n_d && !_ram_we;
+
+always @(posedge clk_sys) begin
+  ram_we_n_d <= _ram_we;
+  snoop_act  <= 1'b0;
+
+  if(sq_push && !sq_full) begin
+    sq_adr[sq_wr[0]] <= ram_address[22:1];
+    sq_dat[sq_wr[0]] <= ram_data;
+    sq_bs [sq_wr[0]] <= {~_ram_bhe, ~_ram_ble};
+    sq_wr              <= sq_wr + 2'd1;
+  end
+
+  if(sq_pace != 2'd0)
+    sq_pace <= sq_pace - 2'd1;
+  else if(!sq_empty) begin
+    snoop_adr_r <= sq_adr[sq_rd[0]];
+    snoop_dat_r <= sq_dat[sq_rd[0]];
+    snoop_bs_r  <= sq_bs [sq_rd[0]];
+    snoop_act   <= 1'b1;
+    sq_rd       <= sq_rd + 2'd1;
+    sq_pace     <= 2'd3;
+  end
+
+  if(!cpu_rst) begin
+    sq_wr   <= 2'd0;
+    sq_rd   <= 2'd0;
+    sq_pace <= 2'd0;
+  end
+end
+
+`else
+wire        snoop_act = 1'b0;   // nothing cached that the chip bus can modify
+wire [22:1] snoop_adr_r = 22'd0;
+wire [15:0] snoop_dat_r = 16'd0;
+wire [1:0]  snoop_bs_r  = 2'd0;
+`endif
+
+wire        cache_ack;
+wire        cache_wb_en;
+wire        cache_req;
+wire [15:0] cache_dat_r;
+// The TG68K starts its next bus cycle right after clkena without dropping
+// its request, but the cache needs to see its cpu_cs deasserted after every
+// acknowledged access. Blanking it during the ready cycle itself (instead of
+// the cycle after, as an extra register did) saves one clock on every single
+// cpu memory access - the same trick minimig uses on mister.
+wire        cache_cs = ram_sel & ~ram_ready;
+reg         cache_fill_ack;
+reg  [15:0] cache_fill_dat;
+
+cpu_cache_new cpu_cache (
+  .clk            (clk_sys),
+  .rst            (!cpu_rst),
+  .cpu_cache_ctrl (cpu_cacr),
+  .cache_inhibit  (1'b0),
+  .cpu_cs         (cache_cs),
+  .cpu_adr        ({6'b000000, ram_addr[22:1]}),
+  .cpu_bs         ({~ram_uds, ~ram_lds}),
+  .cpu_we         (cpu_state == 2'd3),
+  .cpu_ir         (cpu_state == 2'd0),
+  .cpu_dr         (cpu_state == 2'd2),
+  .cpu_dat_w      (ram_din),
+  .cpu_dat_r      (cache_dat_r),
+  .cpu_ack        (cache_ack),
+  .wb_en          (cache_wb_en),
+  .sdr_dat_r      (cache_fill_dat),
+  .sdr_read_req   (cache_req),
+  .sdr_read_ack   (cache_fill_ack),
+  // Snooping is not needed in this configuration: chip ram is not cached
+  // (turbo chip off), kickstart is read only and fast ram is only written
+  // through the cache itself. Disabling it avoids undefined cross port
+  // read-during-write behaviour of the tag block rams on real hardware.
+  .snoop_act      (snoop_act),
+  .snoop_adr      ({6'b000000, snoop_adr_r}),
+  .snoop_dat_w    (snoop_dat_r),
+  .snoop_bs       (snoop_bs_r)
+);
+
+// line fill / write buffer sequencer driving the sdram's second port
+reg  [1:0]  fill_state;     // 0 idle, 1 line read issued, 2 delivering words
+reg  [63:0] fill_line;      // w0..w3 of the aligned 64 bit line
+reg  [1:0]  fill_idx;       // requested (critical) word index
+reg  [1:0]  fill_cnt;
+reg         wbuf_pending;   // a write is in flight on the sdram port
+reg         write_acked;
+reg         wb_req;    // latched pending cache write
+reg         wb_en_d;   // wb_en edge detect
+reg         wr_lock;   // ack delivered, waiting for the cpu to consume it    // current cpu write has been acknowledged
+reg         cache_ack_d;
+reg         fastram_done_d;
+reg         fastram_sel_r;
+reg         fastram_wr_r;
+reg  [22:1] fastram_addr_r;
+reg  [15:0] fastram_din_r;
+reg         fastram_lds_r;
+reg         fastram_uds_r;
+reg         frr_d;               // previous state of the port 2 ack toggle
+wire        fastram_done = (fastram_ready != frr_d);
+wire [1:0]  fill_word = fill_idx + fill_cnt;
+
+always @(posedge clk_sys) begin
+  frr_d           <= fastram_ready;
+  cache_fill_ack  <= 1'b0;
+  ram_write_ready <= 1'b0;
+  cache_ack_d     <= cache_ack;
+
+  if(!cpu_rst) begin
+    fill_state    <= 2'd0;
+    wbuf_pending  <= 1'b0;
+    ram_write_ready <= 1'b0;
+    wb_req        <= 1'b0;
+    wb_en_d       <= 1'b0;
+    wr_lock       <= 1'b0;
+    fastram_sel_r <= 1'b0;
+    fastram_wr_r  <= 1'b0;
+  end else begin
+    // sdram port transaction finished. The read data is sampled one cycle
+    // after the ack has been seen to give the clock domain crossing from
+    // the 85MHz sdram controller a full cycle of settling time.
+    fastram_done_d <= fastram_done;
+    if(fastram_done) begin
+      fastram_sel_r <= 1'b0;
+      wbuf_pending  <= 1'b0;
+    end
+    if(fastram_done_d && (fill_state == 2'd1)) begin
+      fill_line  <= { fastram_dout, fastram_chip48 };
+      fill_cnt   <= 2'd0;
+      fill_state <= 2'd2;
+    end
+
+    case(fill_state)
+      2'd0: if(cache_req && !wbuf_pending && !fastram_sel_r) begin
+              // fetch the aligned 64 bit line containing the requested word
+              fastram_addr_r <= { ram_addr[22:3], 2'b00 };
+              fill_idx       <= ram_addr[2:1];
+              fastram_wr_r   <= 1'b0;
+              fastram_lds_r  <= 1'b0;
+              fastram_uds_r  <= 1'b0;
+              fastram_sel_r  <= 1'b1;
+              fill_state     <= 2'd1;
+            end
+      2'd1: ;  // waiting for the sdram
+      2'd2: begin
+              // deliver the four words starting with the requested one
+              cache_fill_ack <= 1'b1;
+              case(fill_word)
+                2'd0: cache_fill_dat <= fill_line[63:48];
+                2'd1: cache_fill_dat <= fill_line[47:32];
+                2'd2: cache_fill_dat <= fill_line[31:16];
+                2'd3: cache_fill_dat <= fill_line[15: 0];
+              endcase
+              fill_cnt <= fill_cnt + 2'd1;
+              if(fill_cnt == 2'd3) fill_state <= 2'd0;
+            end
+      default: fill_state <= 2'd0;
+    endcase
+
+    // write buffer: the cache raises wb_en once per write (its fsm cycles
+    // through IDLE/WRITE/WB for every accepted cpu write), so the rising
+    // edge marks a new write even when the tg68k keeps ram_sel asserted
+    // between back to back bus cycles (e.g. the two halves of a move.l).
+    // The request is latched so it survives a busy sdram port or a still
+    // draining line fill.
+    wb_en_d <= cache_wb_en;
+    // wr_lock covers [accept .. consuming clkena]: while the (slowed) cpu
+    // still presents the already acknowledged write, the cache fsm may
+    // recycle through IDLE/WRITE and raise wb_en again; those stale edges
+    // must not produce a second acknowledge for the same bus cycle.
+    if(cpu_clkena)              wr_lock <= 1'b0;
+    if(cpu_state != 2'd3)       wb_req  <= 1'b0;   // stale request dies with the write cycle
+    if(cache_wb_en && !wb_en_d && !wr_lock) wb_req <= 1'b1;
+    if((wb_req || (cache_wb_en && !wb_en_d)) && (cpu_state == 2'd3) && !wr_lock &&
+       !wbuf_pending && !fastram_sel_r && (fill_state == 2'd0)) begin
+      fastram_addr_r <= ram_addr[22:1];
+      fastram_din_r  <= ram_din;
+      fastram_lds_r  <= ram_lds;
+      fastram_uds_r  <= ram_uds;
+      fastram_wr_r   <= 1'b1;
+      fastram_sel_r  <= 1'b1;
+      wbuf_pending   <= 1'b1;
+      wb_req         <= 1'b0;
+      wr_lock        <= 1'b1;
+      ram_write_ready<= 1'b1;
+    end
+
+  end
+end
+
+
+
+assign fastram_sel = fastram_sel_r;
+assign fastram_addr = fastram_addr_r;
+assign fastram_lds  = fastram_lds_r;
+assign fastram_uds  = fastram_uds_r;
+assign fastram_din  = fastram_din_r;
+assign fastram_wr   = fastram_wr_r;
+assign ram_dout     = cache_dat_r;
+`else
 assign fastram_addr = ram_addr;
-assign fastram_lds = ram_lds;
-assign fastram_uds = ram_uds;
-assign ram_dout = fastram_dout;
-assign fastram_din = ram_din;
-assign fastram_wr = (cpu_state[1:0]==2'b11) ? 1'b1 : 1'b0;
+assign fastram_lds  = ram_lds;
+assign fastram_uds  = ram_uds;
+assign ram_dout     = fastram_dout;
+assign fastram_din  = ram_din;
+assign fastram_wr   = (cpu_state[1:0]==2'b11) ? 1'b1 : 1'b0;
+`endif
 
 wire [7:0] sdc_byte_out_data_fdc;   
 wire [31:0] sdc_sector_fdc;  // from inside minimig/floppy
@@ -1117,6 +1393,8 @@ wire [15:0] JOY3 = 16'h0000;
 wire [15:0] JOYA0 = 16'h0000;
 wire [15:0] JOYA1 = 16'h0000;
 
+/* ======================================================================================== */
+/* =============================== internal ROM and RAM =================================== */
 /* ======================================================================================== */
 /* =============================== internal ROM and RAM =================================== */
 /* ======================================================================================== */

--- a/src/scripts/build_aga_ebr2.tcl
+++ b/src/scripts/build_aga_ebr2.tcl
@@ -41,6 +41,8 @@ add_file minimig-aga/agnus_copper.v
 add_file minimig-aga/agnus_spritedma.v
 add_file minimig-aga/denise.v
 add_file minimig-aga/denise_bitplane_shifter.v
+add_file minimig-aga/bitplane_ram.v
+add_file minimig-aga/sprite_ram.v
 add_file minimig-aga/denise_collision.v
 add_file minimig-aga/denise_colortable.v
 add_file minimig-aga/denise_playfields.v
@@ -107,4 +109,6 @@ set_option -multi_boot 0
 set_option -mspi_jump 0
 set_option -loading_rate 25.000
 
+set_option -place_option 1
 run all
+

--- a/src/tang/nano20k/nanomig_020.sdc
+++ b/src/tang/nano20k/nanomig_020.sdc
@@ -8,9 +8,13 @@ create_clock -name clk_hdmi -period 7 -waveform {0 3} [get_nets {clk_pixel_x5}] 
 create_clock -name clk_osc -period 37 -waveform {0 18} [get_ports {clk}] -add
 create_clock -name clk_spi -period 14.085 -waveform {0 7.04} [get_ports {mspi_clk}] -add
 create_generated_clock -name clk28 -source [get_pins {amigaclks/sysclk_inst/CLKOUT}] -master_clock clk85 -divide_by 3 [get_pins {amigaclks/sysclk_inst/CLKOUTD3}]
-
+// every multi cycle setup exception needs its hold counterpart, otherwise the
+// hold analysis still assumes a single cycle relationship between the two
+// domains and reports thousands of meaningless violations
 set_multicycle_path -from [get_clocks {clk28}] -to [get_clocks {clk85}] 4
+set_multicycle_path -from [get_clocks {clk28}] -to [get_clocks {clk85}] -hold 3
 set_multicycle_path -from [get_clocks {clk85}] -to [get_clocks {clk28}] -start 2
+set_multicycle_path -from [get_clocks {clk85}] -to [get_clocks {clk28}] -hold -start 1
 
 set_false_path -from [get_cells {sysctrl/system_cpu*}]
 set_false_path -from [get_cells {sysctrl/system_chipset*}]
@@ -19,3 +23,25 @@ set_false_path -from [get_cells {sysctrl/system_chipmem*}]
 set_false_path -from [get_cells {sysctrl/system_slowmem*}]
 set_false_path -from [get_cells {sysctrl/system_fastmem*}]
 set_false_path -from [get_cells {sysctrl/system_volume*}]
+
+// the TG68K advances at most every second clk28 cycle (CPU_SLOW14 in
+// cpu_wrapper.v), so all its internal register to register paths are
+// true two cycle paths
+set_multicycle_path -from [get_regs {*cpu_inst_p/*}] -to [get_regs {*cpu_inst_p/*}] -setup -end 2
+set_multicycle_path -from [get_regs {*cpu_inst_p/*}] -to [get_regs {*cpu_inst_p/*}] -hold -end 1
+// the TG68K register file is distributed LUT ram, not covered by get_regs,
+// so additionally relax paths ending at any pin inside the cpu core
+set_multicycle_path -from [get_regs {*cpu_inst_p/*}] -to [get_pins {*cpu_inst_p/*/DI* *cpu_inst_p/*/AD* *cpu_inst_p/*/WRE}] -setup -end 2
+set_multicycle_path -from [get_regs {*cpu_inst_p/*}] -to [get_pins {*cpu_inst_p/*/DI* *cpu_inst_p/*/AD* *cpu_inst_p/*/WRE}] -hold -end 1
+// The hdmi audio sample words cross from the 48kHz audio clock into the pixel
+// clock domain through a toggle handshake: the data is written a full audio
+// period (~10us) before the synchronized toggle releases the capture, so the
+// single cycle relationship the analyzer assumes here is meaningless. Left
+// unconstrained the path is only met by lucky placement, and when it is not
+// the captured sample words pick up wrong bits - audible as noisy samples.
+set_false_path -from [get_regs {*packet_picker/audio_sample_word_transfer*}] -to [get_regs {*packet_picker/audio_sample_word_buffer*}]
+// The disk length register reaches the blitter through the dma priority logic.
+// Both live in the chipset, which advances on the 7MHz (and slower) clock
+// enables, so these are multi cycle paths on the 28MHz clock.
+set_multicycle_path -from [get_regs {*PAULA1/pf1/dsklen*}] -to [get_regs {*AGNUS1/bl1/*}] -setup -end 4
+set_multicycle_path -from [get_regs {*PAULA1/pf1/dsklen*}] -to [get_regs {*AGNUS1/bl1/*}] -hold -end 3

--- a/src/tang/nano20k/top_020.sv
+++ b/src/tang/nano20k/top_020.sv
@@ -10,6 +10,15 @@
 */
 
 `define ENABLE_TG68K
+`define ENABLE_AGA   // offer the AGA chipset in the menu
+`define ENABLE_AGA   // offer the AGA chipset in the menu
+`define CPU_SLOW14   // run TG68K at 14MHz effective (A1200 speed) for timing closure
+`define ENABLE_CACHE // MiSTer cpu cache between the cpu and the sdram (cached kickstart + fast ram)
+// `define TURBO_KICK   // bisect build: turbo kick via the plain fast path, no cache
+// `define DISABLE_IDE  // v32 experiment: cache + ide together
+`define NO_WS2812   // drop the rgb status led to make room for cache + ide
+`define DENISE_EBR   // block ram based bitplane and sprite buffers, saves logic
+`define CHIPRAM_CACHE // cache chip ram instruction fetches too (a1200 68ec020 style) with chip bus snooping
 
 module top(
   input			clk,
@@ -84,7 +93,8 @@ wire [5:0] db9_joy1 = { !js1[5], !js1[0], !js1[2], !js1[1], !js1[4], !js1[3] };
 wire [5:0]	leds;
 assign leds[5] = |sd_wr;
 assign leds[4] = |sd_rd;
-assign leds_n = ~leds;  
+assign leds_n = ~leds;
+
 
 // ============================== clock generation ===========================
    
@@ -208,14 +218,19 @@ wire spi_io_din = spi_ext?m0s[1]:spi_dat;
 wire spi_io_ss = spi_ext?m0s[2]:spi_csn;
 wire spi_io_clk = spi_ext?m0s[3]:spi_sclk;
 
-// connect to ws2812 led
+// connect to ws2812 led. The rgb status led costs ~150 luts which the cache
+// plus ide combination needs, so it is dropped when space is tight.
 wire [23:0] ws2812_color;
+`ifdef NO_WS2812
+assign ws2812 = 1'b0;
+`else
 ws2812 ws2812_inst (
     .clk(clk_28m),
 	.reset(rst_28m),
     .color(ws2812_color),
     .data(ws2812)
 );
+`endif
 
 // interface to M0S MCU
 wire       mcu_sys_strobe;        // mcu message byte valid for sysctrl
@@ -458,7 +473,11 @@ hid hid (
         .joystick1(hid_joy1)
          );   
 
-sysctrl sysctrl (
+sysctrl #(
+`ifdef ENABLE_AGA
+        .AGA(1)
+`endif
+        ) sysctrl (
         .clk(clk_28m),
         .reset(rst_28m),
 
@@ -592,6 +611,8 @@ wire fastram_wr;
 wire fastram_ready;
    
 wire [15:0] sdram_dout;
+wire [47:0] chip48;   // upper 48 bits of 64 bit aligned chipram reads (AGA fmode>0)
+wire [47:0] fastram_chip48; // wide read data of the cpu cache port
 
 assign ram_din = sdram_dout;
 
@@ -619,7 +640,9 @@ nanomig nanomig
 
  .pwr_led(leds[0]),
  .fdd_led(leds[1]),
+`ifndef DISABLE_IDE
  .hdd_led(leds[2]),
+`endif
  
  .memory_config(memory_config),
  .fastram_config(fastram_config),
@@ -627,7 +650,9 @@ nanomig nanomig
  .chipset_config(chipset_config),
  .floppy_config(floppy_config),
  .video_config(video_config),
+`ifndef DISABLE_IDE
  .ide_config(ide_config),
+`endif
 
  // video
  .hs(hs_n), // horizontal sync
@@ -672,7 +697,7 @@ nanomig nanomig
  ._ram_ble(ram_be[0]),      // sram lower byte select
  ._ram_we(ram_we_n),        // sram write enable
  ._ram_oe(ram_oe_n),        // sram output enable
- .chip48(48'd0),
+ .chip48(chip48),
  .refresh(ram_refresh),
  
  .fastram_sel(fastram_sel),
@@ -680,6 +705,9 @@ nanomig nanomig
  .fastram_lds(fastram_lds),
  .fastram_uds(fastram_uds),
  .fastram_dout(fastram_dout),
+ .fastram_chip48(fastram_chip48),
+`ifdef ENABLE_CACHE
+`endif
  .fastram_din(fastram_din),
  .fastram_wr(fastram_wr),
  .fastram_ready(fastram_ready)
@@ -832,7 +860,9 @@ wire [21:0] sdram_addr    =
 
 assign O_sdram_clk = clk_85m_shifted;
 
-sdram #(.DATA_WIDTH(32), .RAS_WIDTH(11), .CAS_WIDTH(8) ) sdram (
+sdram #(.DATA_WIDTH(32), .RAS_WIDTH(11), .CAS_WIDTH(8),
+        .CHIP48_BURST(1)   // the wide 64 bit fetch AGA needs
+        ) sdram (
 	.sd_data    ( IO_sdram_dq   ), // 32 bit bidirectional data bus
 	.sd_addr    ( O_sdram_addr  ), // 11 bit multiplexed address bus
 	.sd_dqm     ( O_sdram_dqm   ), // two byte masks
@@ -853,6 +883,7 @@ sdram #(.DATA_WIDTH(32), .RAS_WIDTH(11), .CAS_WIDTH(8) ) sdram (
 
 	.din        ( sdram_din     ), // data input from chipset/cpu
 	.dout       ( sdram_dout    ),
+	.dout48     ( chip48        ), // wide fetch data for AGA fmode>0
 	.addr       ( sdram_addr    ), // 22 bit word address
 	.ds         ( sdram_be      ), // upper/lower data strobe
 	.cs         ( sdram_cs      ), // cpu/chipset requests read/wrie
@@ -860,6 +891,7 @@ sdram #(.DATA_WIDTH(32), .RAS_WIDTH(11), .CAS_WIDTH(8) ) sdram (
 
 	.p2_din        ( fastram_din     ), // data input from chipset/cpu
 	.p2_dout       ( fastram_dout    ),
+	.p2_dout48     ( fastram_chip48  ), // wide read data for the cache line fills
 	.p2_addr       ( fastram_addr    ), // 22 bit word address
 	.p2_ds         ( fastram_be      ), // upper/lower data strobe
 	.p2_cs         ( fastram_sel     ), // cpu/chipset requests read/wrie
@@ -892,7 +924,7 @@ flash flash (
 // latch audio, so it's stable during 48khz transfer
 reg [15:0] audio_reg [2]; // 16 bit signed audio for HDMI
 
-// Sign-extend inputs to 16-bit BEFORE mixing – intermediate sum
+// Sign-extend inputs to 16-bit BEFORE mixing  intermediate sum
 // cannot overflow, result always fits back in 15 bit.
 wire signed [15:0] audio_left_s  = {{1{audio_left[14]}},  audio_left};
 wire signed [15:0] audio_right_s = {{1{audio_right[14]}}, audio_right};
@@ -932,7 +964,7 @@ always @(posedge clk_pixel) begin
 
     // --- Volume scaling ----------------------------------------
         // mixed_audio_* are reg signed [14:0], so >>> is always
-        // arithmetic – no $signed() wrapper required.
+        // arithmetic â€“ no $signed() wrapper required.
         case (osd_volume) 
             3'b100: begin // 100%
                 scaled_audio_left  <= mixed_audio_left;
@@ -961,7 +993,7 @@ always @(posedge clk_pixel) begin
         endcase
 
         // --- HDMI audio register ----------------------------------
-        // Convert signed two's complement → offset binary:
+        // Convert signed two's complement â†’ offset binary:
         // flip sign bit (bit 14).  Bit 15 = 0 (15-bit audio in 16-bit slot).
         // Explicit per-element assignment avoids unpacked-array ambiguity.
         audio_reg[0] <= {1'b0, ~scaled_audio_left[14],  scaled_audio_left[13:0]};
@@ -974,6 +1006,7 @@ wire [2:0] tmds;
 wire tmds_clock;
 
 wire vreset, vpal, interlace, short_frame;
+
 video_analyzer video_analyzer (
     .clk         ( clk_28m   ),
     .hs          ( hs_n      ),


### PR DESCRIPTION
This brings the AGA chipset, the 68020 and a working cpu cache to the
GW2AR-18 of the Tang Nano 20K, with IDE still enabled. Kickstart 3.1,
Workbench and AGA demos run, and SysInfo measures **4454 dhrystones using
chip ram only**, against roughly 995 for a stock A1200.

### Enabling AGA

AGA is offered in the menu through the `sysctrl` AGA parameter, exactly as
the icepi-zero and gw5a targets do it. Two things are needed beyond that:

* `CHIP48_BURST(1)` on the sdram controller, for the wide 64 bit fetch the
  chipset relies on. Without it the machine comes up far enough to show the
  osd menu but never draws a single amiga frame - worth remembering, since
  it fails silently.
* `DENISE_EBR` for the block ram based bitplane and sprite buffers. Not
  optional here: the register variant does not leave enough logic for the
  cache and the design no longer fits.

### 14MHz cpu

`CPU_SLOW14` advances the TG68K at most every second clk28 cycle, which
turns every internal register path into a true two cycle path. That is what
makes timing closure possible on this device. The sdc carries the matching
multicycle exceptions, including the ones for the lut ram register file
that `get_regs` does not cover.

### The cache

MiSTer's `cpu_cache_new` with a Gowin friendly `dpram`, plus the glue that
connects it to sdram port 2: critical word first line fills, a write buffer
and chip bus snooping. The port 2 wide read (`p2_dout48`) mirrors the
existing PORT_1 collection.

Three bugs had to be fixed before it was stable. Each only shows up in one
specific situation, which is probably why the cache has a reputation for
being flaky:

| symptom | cause |
|---|---|
| hangs during the kickstart memory sizing, only with fast ram | the write path acknowledged the first half of a `move.l` and then waited forever, because the TG68K never drops its request between the two halves |
| guru a few seconds after a demo loads its next part; without fast ram even ramlib fails to load | the snoop was fed the live chip bus signals, but the write strobe lasts about two of the four clocks of a bus cycle while the cache samples address and data three clocks later, so freshly loaded code kept executing from stale lines |
| black screen while the kickstart overlay is active | turbo chip has to be gated by `~ovl`, otherwise instruction fetches read chip ram instead of the rom |

The write acknowledge is now an edge detect on the cache write enable plus
a lock that clears when the cpu consumes it; snoop address, data and byte
selects are latched and handed over at a fixed pace.

### Chip ram caching

Chip ram is cached with the data cache **on**. Leaving it off, which mirrors
the 68EC020 faithfully, sends every chip ram data access back to the 561ns
chip bus handshake and starves the cpu. On hardware that was slowing music,
flickering sprites and one demo part that never drew at all. Enabling it
took chip-ram-only dhrystones from 1805 to 4454, and all three symptoms
disappeared.

### Timing

Every multi cycle setup exception needs its hold counterpart. Without the
pairs the hold analysis still assumes a single cycle relationship between
the 28MHz and 85MHz domains and reports 1441 violations. With them the
build closes at 0 setup and 0 hold - the single remaining hold violation on
this branch is on the `clk_audio` generation and comes from the integer
audio divider, which #136 replaces.

### Fit

93% of the device, and placement is tight - anything added later will need
room from somewhere. `agnus_bitplanedma.v` also carries Alastair's AGA
fixes, which the AGA demos need.

### Testing

Verified on hardware: Kickstart 3.1 and Workbench, Nexus 7 and other AGA
demos, IDE enabled, with and without fast ram. The simulation testbench in
`sim/` was extended to drive the real sdram controller against a behavioural
memory model, with environment switches for chipset, cpu, fast ram and chip
ram size so hardware configurations can be reproduced.
