### PR TITLE
Update sprite shifter write bank only when DAT reg is written

### DIFF
--- a/src/minimig-aga/denise_sprites_shifter.v
+++ b/src/minimig-aga/denise_sprites_shifter.v
@@ -182,14 +182,12 @@ always @(posedge clk) begin
 
     if (aen) begin
       // initiate data transfer and continue for the next 4 cycles
+      // also ensure we won't overwrite currently read data
       case (address)
-        DATA: begin ram_wea <= 1; bankwr_reg <= 0; end
-        DATB: begin ram_wea <= 1; bankwr_reg <= 1; end
+        DATA: begin ram_wea <= 1; bankwr_reg <= 0; bankwr_buf <= ~bankrd_buf; end
+        DATB: begin ram_wea <= 1; bankwr_reg <= 1; bankwr_buf <= ~bankrd_buf; end
         default: ;
       endcase
-
-      // ensure we won't overwrite currently read data
-      bankwr_buf <= ~bankrd_buf;
     end
   end
 end


### PR DESCRIPTION
this fixes a glitch discovered yesterday by me ; sprite shifter bank was incorrectly updated when an arbirary sprite shifter register was accessed; this should only happen when DAT register is accessed

<img width="1024" height="769" alt="image" src="https://github.com/user-attachments/assets/57245c80-1936-4b66-829f-e15b325f461a" />
