### PR TITLE
Add cache for IcePi Zero 25k and further resource usage optimizations

### DIFF
--- a/src/lattice/icepi-zero/nanomig.ldf
+++ b/src/lattice/icepi-zero/nanomig.ldf
@@ -153,6 +153,12 @@
         <Source name="../../minimig-aga/cpu_wrapper.v" type="Verilog" type_short="Verilog">
             <Options/>
         </Source>
+        <Source name="../../minimig-aga/cpu_cache_new.v" type="Verilog" type_short="Verilog">
+            <Options/>
+        </Source>
+        <Source name="../../minimig-aga/dpram.v" type="Verilog" type_short="Verilog">
+            <Options/>
+        </Source>
         <Source name="../../minimig-aga/denise_collision.v" type="Verilog" type_short="Verilog">
             <Options/>
         </Source>

--- a/src/lattice/icepi-zero/nanomig.lpf
+++ b/src/lattice/icepi-zero/nanomig.lpf
@@ -265,3 +265,7 @@ BLOCK PATH FROM CELL "sysctrl/system_chipmem*" ;
 BLOCK PATH FROM CELL "sysctrl/system_slowmem*" ;
 BLOCK PATH FROM CELL "sysctrl/system_fastmem*" ;
 BLOCK PATH FROM CELL "sysctrl/system_volume*" ;
+
+BLOCK PATH FROM CELL "*packet_picker/audio_sample_word_transfer*" ;
+
+MULTICYCLE FROM CELL "*PAULA1/pf1/dsklen*" TO CELL "*AGNUS1/bl1/*" 4X ;

--- a/src/lattice/icepi-zero/nanomig.sdc
+++ b/src/lattice/icepi-zero/nanomig.sdc
@@ -4,7 +4,9 @@ create_clock -name {clk_pixel_x5} -period 7.06 [get_nets {clk_pixel_x5}]
 create_clock -name {clk_85m} -period 11.7 [get_nets {clk_85m}]
 
 set_multicycle_path -from [get_clocks {clk_pixel}] -to [get_clocks {clk_85m}] 2
+set_multicycle_path -from [get_clocks {clk_pixel}] -to [get_clocks {clk_85m}] -hold 3
 set_multicycle_path -from [get_clocks {clk_85m}] -to [get_clocks {clk_pixel}] -start 2
+set_multicycle_path -from [get_clocks {clk_85m}] -to [get_clocks {clk_28}] -hold -start 1
 
 set_false_path -from [get_cells {nanomig.minimig.AGNUS1.bc1.beamcon0*}]
 
@@ -15,3 +17,8 @@ set_false_path -from [get_cells {sysctrl.system_chipmem*}]
 set_false_path -from [get_cells {sysctrl.system_slowmem*}]
 set_false_path -from [get_cells {sysctrl.system_fastmem*}]
 set_false_path -from [get_cells {sysctrl.system_volume*}]
+
+set_false_path -from [get_cells {*packet_picker/audio_sample_word_transfer*}]
+
+set_multicycle_path -from [get_cells {*PAULA1/pf1/dsklen*}] -to [get_cells {*AGNUS1/bl1/*}] -setup 4
+set_multicycle_path -from [get_cells {*PAULA1/pf1/dsklen*}] -to [get_cells {*AGNUS1/bl1/*}] -hold 3

--- a/src/lattice/icepi-zero/nanomig1.sty
+++ b/src/lattice/icepi-zero/nanomig1.sty
@@ -30,7 +30,7 @@
     <Property name="PROP_BIT_MIFFileBitGen" value="" time="0"/>
     <Property name="PROP_BIT_NoHeader" value="False" time="0"/>
     <Property name="PROP_BIT_OutFormatBitGen" value="Bit File (Binary)" time="0"/>
-    <Property name="PROP_BIT_OutFormatBitGen_REF" value="" time="0"/>
+    <Property name="PROP_BIT_OutFormatBitGen_REF" value="Bit File (Binary)" time="0"/>
     <Property name="PROP_BIT_OutFormatPromGen" value="Intel Hex 32-bit" time="0"/>
     <Property name="PROP_BIT_ParityCheckBitGen" value="True" time="0"/>
     <Property name="PROP_BIT_RemZeroFramesBitGen" value="False" time="0"/>

--- a/src/lattice/icepi-zero/top.sv
+++ b/src/lattice/icepi-zero/top.sv
@@ -12,7 +12,11 @@
 // `define INFER_DPRAM
 `define ENABLE_TG68K
 `define ENABLE_AGA
+`define NO_WS2812    // drop the rgb status led to make room for cache + ide
 `define DENISE_EBR   // use the block ram based bitplane and sprite buffers
+`define ENABLE_CACHE
+`define CHIPRAM_CACHE
+// `define CPU_SLOW14   // run TG68K at 14MHz effective (A1200 speed) for timing closure
 // `define DISABLE_IDE       // when using inferred ram, this exceeds the chip
 // `define HDMI_TEST_PATTERN  // display static test pattern on HDMI instead of amiga video
 // `define ENABLE_INT_ROM     // enable 2k internal test rom in nanomig.v
@@ -170,27 +174,28 @@ wire       osd_stereo_mix;      // 0=off, 1=on
 
 wire	   rom_download_in_progress;
 
-// generate a reset for some time after rom has been initialized
-reg [15:0] reset_cnt = 16'hffff;
+// this is the reset that goes into the nanomig itself
+reg nanomig_reset = 1;
 
 always @(posedge clk_28m, posedge rst_28m) begin
-    if(rst_28m || !rom_done || !reset_n || osd_reset || kbd_reset || rom_download_in_progress)
-        reset_cnt <= 16'hffff;
-    else if(reset_cnt != 0)
-        reset_cnt <= reset_cnt - 16'd1;
+    if (rst_28m)
+        nanomig_reset <= 1'b1;
+    else
+        nanomig_reset <= !rom_done || !reset_n || osd_reset || kbd_reset || rom_download_in_progress;
 end
-
-// this is the reset that goes into the nanomig itself
-wire cpu_reset = reset_cnt != 0;
 
 // connect to ws2812 led
 wire [23:0] ws2812_color;
+`ifdef NO_WS2812
+assign ws2812 = 1'b0;
+`else
 ws2812 #(.CLK_FRE(`PIXEL_CLOCK)) ws2812_inst (
     .clk(clk_28m),
     .reset(rst_28m),
     .color(ws2812_color),
     .data(ws2812)
 );
+`endif
 
 // -------------------------- M0S MCU interface -----------------------
 // intn and dout are outputs driven by the FPGA to the MCU
@@ -491,7 +496,11 @@ sysctrl #(
 
         .buttons( {!user_n, !reset_n} ),
         .leds(),
+`ifdef NO_WS2812
+        .color()
+`else
         .color(ws2812_color)
+`endif
 );
 
 // digital 12 bit video
@@ -588,6 +597,7 @@ wire fastram_ready;
 
 wire [15:0] sdram_dout;
 wire [47:0] sdram_dout48;
+wire [47:0] fastram_chip48;
 
 assign ram_din = sdram_dout;
 assign chip48_din = sdram_dout48;
@@ -610,7 +620,7 @@ wire [5:0] ide_config = { 5'b10000, osd_ide_enable };
 nanomig nanomig
 (
  .clk_sys(clk_28m),
- .reset(cpu_reset),
+ .reset(nanomig_reset),
  .por(rst_28m),
 
  .clk7_en(clk7_en),
@@ -683,6 +693,7 @@ nanomig nanomig
  .fastram_lds(fastram_lds),
  .fastram_uds(fastram_uds),
  .fastram_dout(fastram_dout),
+ .fastram_chip48(fastram_chip48),
  .fastram_din(fastram_din),
  .fastram_wr(fastram_wr),
  .fastram_ready(fastram_ready)
@@ -871,6 +882,7 @@ sdram #(
 
 	.p2_din        ( fastram_din     ), // data input from cpu
 	.p2_dout       ( fastram_dout    ),
+	.p2_dout48     ( fastram_chip48  ), // wide read data for the cache line fills
 	.p2_addr       ( fastram_addr    ), // 22 bit word address
 	.p2_ds         ( fastram_be      ), // upper/lower data strobe
 	.p2_cs         ( fastram_sel     ), // cpu requests read/wrie
@@ -920,18 +932,22 @@ reg signed [14:0] scaled_audio_left;
 reg signed [14:0] scaled_audio_right;
 
 // generate 48khz audio clock
-// An integer divider cannot land on 48kHz, and the truncation leaves the
-// stream running fast, so sinks drop a chunk of audio every few seconds. A
-// phase accumulator keeps the fractional part.
-localparam [31:0] AUDIO_INC = (64'd48000 <<< 32) / `PIXEL_CLOCK;
-reg [31:0] aclk_acc;
-reg        clk_audio;
-reg        aclk_tick;
+// An integer divider cannot hit 48kHz: 28500000 / 48000 / 2 = 296.88, and the
+// truncation leaves the stream running fast, which makes sinks drop a chunk of
+// audio every few seconds. A phase accumulator keeps the fractional part.
+localparam integer AUDIO_RATE = 48000;
+localparam integer AUDIO_ACC_WIDTH = $clog2(`PIXEL_CLOCK + AUDIO_RATE);
+
+localparam [AUDIO_ACC_WIDTH-1:0] AUDIO_INC = ((AUDIO_ACC_WIDTH*2)'(AUDIO_RATE) <<< AUDIO_ACC_WIDTH) / `PIXEL_CLOCK;
+
+reg [AUDIO_ACC_WIDTH-1:0] aclk_acc;
+reg                       clk_audio;
+reg                       aclk_tick;
 
 always @(posedge clk_pixel) begin
     aclk_acc  <= aclk_acc + AUDIO_INC;
-    clk_audio <= aclk_acc[31];                 // msb of the accumulator = 48kHz
-    aclk_tick <= (clk_audio != aclk_acc[31]);  // high the cycle after each edge
+    clk_audio <= aclk_acc[AUDIO_ACC_WIDTH-1];                 // msb of the accumulator = 48kHz
+    aclk_tick <= (clk_audio != aclk_acc[AUDIO_ACC_WIDTH-1]);  // high the cycle after each edge
 
     // The sample word must not change on the same clk_pixel edge that toggles
     // clk_audio: the hdmi module latches it on that very edge, so data and
@@ -990,6 +1006,8 @@ always @(posedge clk_pixel) begin
         // Convert signed two's complement → offset binary:
         // flip sign bit (bit 14).  Bit 15 = 0 (15-bit audio in 16-bit slot).
         // Explicit per-element assignment avoids unpacked-array ambiguity.
+        // audio_reg[0] <= {audio_left[14], audio_left};
+        // audio_reg[1] <= {audio_right[14], audio_right};
         audio_reg[0] <= {scaled_audio_left[14], scaled_audio_left[14:0]};
         audio_reg[1] <= {scaled_audio_right[14], scaled_audio_right[14:0]};
 
@@ -1009,7 +1027,8 @@ video_analyzer video_analyzer (
 );
 
 hdmi #(
-    .AUDIO_RATE(48000), .AUDIO_BIT_WIDTH(16),
+    .AUDIO_RATE(AUDIO_RATE),
+    .AUDIO_BIT_WIDTH(16),
     .VENDOR_NAME( { "MiSTle", 16'd0} ),
     .PRODUCT_DESCRIPTION( {"Nanomig", 72'd0} )
 ) hdmi(

--- a/src/misc/sd_card.v
+++ b/src/misc/sd_card.v
@@ -187,8 +187,31 @@ wire [2:0] drive =
 // start sector has to be known and the core will read and
 // write from and to the sd card without and further interaction
 // with the Companion.
-reg [31:0] direct_start [8];   
-wire	   direct_enable = direct_start[drive] != 32'd0;   
+//
+// This 8-entry x 32-bit table is written by the MCU (indexed by
+// image_target) and read by the core request logic (indexed by
+// drive). Neither address is ever a function of the other, so a
+// single synchronous write port plus a single asynchronous read
+// port (dual-port pseudo RAM) is enough -- no address muxing
+// between sources is needed. This shape lets ECP5 synthesis infer
+// LUTRAM instead of a bank of muxed flip-flops.
+reg [31:0] direct_start [8];
+
+wire  [2:0] direct_start_waddr = image_target[2:0];
+reg         direct_start_we;
+reg  [31:0] direct_start_wdata;
+
+wire  [2:0] direct_start_raddr = drive;
+wire [31:0] direct_start_rdata = direct_start[direct_start_raddr];
+
+// Asynchronous read
+wire direct_enable = direct_start_rdata != 32'd0;
+
+// Synchronous write
+always @(posedge clk) begin
+	if(direct_start_we)
+		direct_start[direct_start_waddr] <= direct_start_wdata;
+end
 `endif
    
 wire [7:0] doutb;
@@ -241,7 +264,7 @@ sector_dpram buffer(
 reg	      rom_image_trigger_irq;   
 `endif
    
-always @(posedge clk) begin
+always @(posedge clk, negedge rstn) begin
    reg	  startD;   
    
    if(!rstn) begin
@@ -307,21 +330,23 @@ reg reset_D;
 `endif   
 `endif   
 
+reg [15:0] fifo_available;
 
 // register the rising edge of rstart and clear it once
 // it has been reported to the MCU
-always @(posedge clk) begin
+always @(posedge clk, negedge rstn) begin
    if(!rstn) begin
-	  byte_cnt <= 4'd15;
+      byte_cnt <= 4'd15;
       command <= 8'hff;
       rstart_int <= 1'b0;
       wstart_int <= 1'b0;
       image_size <= 64'd0;
       image_mounted <= 8'b00000000;
-	  dinb_we <=1'b0;
+      direct_start_we <= 1'b0;
+      dinb_we <=1'b0;
 `ifdef NO_COMPANION
 `ifdef IMAGE_SIZE
-	  reset_D <= 1'b1;   
+      reset_D <= 1'b1;
       image_size <= `IMAGE_SIZE;
 `endif
 `endif
@@ -344,6 +369,7 @@ always @(posedge clk) begin
 	  core_request <= CORE_REQ_IDLE;	  
    end else begin
       image_mounted <= 8'b00000000;
+      direct_start_we <= 1'b0;
 
 `ifdef NO_COMPANION
 `ifdef IMAGE_SIZE
@@ -485,7 +511,7 @@ always @(posedge clk) begin
 		 if(start_any && direct_enable && core_request == CORE_REQ_IDLE) begin
 			$display("sd_card.v: Direct request for drive %0d, sector %0d", drive, rsector);
 			
-			core_sector <= direct_start[drive] + rsector;
+			core_sector <= direct_start_rdata + rsector;
 			if(rstart_any) core_request <= CORE_REQ_READ;
 			if(wstart_any) core_request <= CORE_REQ_WRITE;
 		 end
@@ -594,11 +620,10 @@ always @(posedge clk) begin
 			   if(byte_cnt == 4'd3) image_size[15:8]  <= data_in;
 			   if(byte_cnt == 4'd4) begin 
 				  image_size[7:0] <= data_in;
-				  if(image_target <= 8'd7) begin  // images 0..7 are supported
-					 $display("sd_card.v: MCU inserted image %0d with %0d bytes", image_target, { image_size[63:8], data_in } );
-					 direct_start[image_target] <= 32'd0;
-					 image_mounted[image_target] <= 1'b1;
-				  end
+				  image_mounted[image_target] <= 1'b1;
+				  direct_start_wdata <= 32'b0;
+				  direct_start_we <= 1'b1;
+				  $display("sd_card.v: MCU inserted image %0d with %0d bytes", image_target, { image_size[63:8], data_in } );
 			   end
 			end
 			
@@ -629,17 +654,16 @@ always @(posedge clk) begin
 			
 			// SDC CMD 6: ENABLE DIRECT ACCESS
 			if(command == 8'd6) begin
-			   reg [23:0] ds;
-			   
 			   // MCU reports that the core may access the image
 			   // directy without sector translation
 			   if(byte_cnt == 4'd0) image_target <= data_in;
-               if(byte_cnt == 4'd1) ds[23:16] <= data_in;
-               if(byte_cnt == 4'd2) ds[15: 8] <= data_in;
-               if(byte_cnt == 4'd3) ds[ 7: 0] <= data_in;
-               if(byte_cnt == 4'd4) begin
-				  direct_start[image_target] <= { ds, data_in };
-				  $display("sd_card.v: MCU direct start %0d with offset %0d(%8x)", image_target, { ds, data_in }, { ds, data_in });
+			   if(byte_cnt == 4'd1) direct_start_wdata[31:24] <= data_in;
+			   if(byte_cnt == 4'd2) direct_start_wdata[23:16] <= data_in;
+			   if(byte_cnt == 4'd3) direct_start_wdata[15: 8] <= data_in;
+			   if(byte_cnt == 4'd4) begin
+				   direct_start_wdata[ 7: 0] <= data_in;
+				   direct_start_we <= 1'b1;
+				   $display("sd_card.v: MCU direct start %0d with offset %0d(%8x)", image_target, { direct_start_wdata[31:8], data_in }, { direct_start_wdata[31:8], data_in });
 			   end
 			end
 
@@ -647,20 +671,20 @@ always @(posedge clk) begin
             if(command == 8'd7) begin
                // MCU reports that some large image has been inserted.
                if(byte_cnt == 4'd0) image_target <= data_in;
-               if(byte_cnt == 4'd1) image_size[63:56] <= data_in;
-               if(byte_cnt == 4'd2) image_size[55:48] <= data_in;
-               if(byte_cnt == 4'd3) image_size[47:40] <= data_in;
+               // it should be ok to limit image size to 1TiB
+               if(byte_cnt == 4'd1) image_size[63:56] <= 8'h00;
+               if(byte_cnt == 4'd2) image_size[55:48] <= 8'h00;
+               if(byte_cnt == 4'd3) image_size[47:40] <= 8'h00;
                if(byte_cnt == 4'd4) image_size[39:32] <= data_in;
                if(byte_cnt == 4'd5) image_size[31:24] <= data_in;
                if(byte_cnt == 4'd6) image_size[23:16] <= data_in;
                if(byte_cnt == 4'd7) image_size[15:8]  <= data_in;
-               if(byte_cnt == 4'd8) begin 
-                  image_size[7:0]   <= data_in;
-                  if(image_target <= 8'd7) begin // images 0..7 are supported
-					 $display("sd_card.v: MCU inserted large image %0d with %0d bytes", image_target, { image_size[63:8], data_in } );
-					 direct_start[image_target] <= 32'd0;
-                     image_mounted[image_target] <= 1'b1;
-				  end
+               if(byte_cnt == 4'd8) begin
+                  image_size[7:0] <= data_in;
+                  image_mounted[image_target] <= 1'b1;
+                  direct_start_wdata <= 32'b0;
+                  direct_start_we <= 1'b1;
+                  $display("sd_card.v: MCU inserted large image %0d with %0d bytes", image_target, { image_size[63:8], data_in } );
                end
             end
 
@@ -680,7 +704,6 @@ always @(posedge clk) begin
 					   // TODO: Is this latch really needed? It's meant to prevent inconsitant
 					   // values to be returned to the core if the fifo changes between the
 					   // transfer of the different reply bytes
-					   reg [15:0] fifo_available;					   
 					   
 					   // send number of bytes free in the fifo
 					   if(byte_cnt == 4'd1) begin

--- a/src/tang/nano20k/top_020.sv
+++ b/src/tang/nano20k/top_020.sv
@@ -171,18 +171,15 @@ wire       osd_stereo_mix;      // 0=off, 1=on
 
 wire	   rom_download_in_progress;
 
-// generate a reset for some time after rom has been initialized
-reg [15:0] reset_cnt = 16'hffff;
+// this is the reset that goes into the nanomig itself
+reg nanomig_reset = 1;
 
 always @(posedge clk_28m, posedge rst_28m) begin
-    if(rst_28m || !rom_done || reset || osd_reset || kbd_reset || rom_download_in_progress)
-        reset_cnt <= 16'hffff;
-    else if(reset_cnt != 0)
-        reset_cnt <= reset_cnt - 16'd1;
+    if (rst_28m)
+        nanomig_reset <= 1'b1;
+    else
+        nanomig_reset <= !rom_done || reset || osd_reset || kbd_reset || rom_download_in_progress;
 end
-
-// this is the reset that goes into the nanomig itself
-wire cpu_reset = |reset_cnt;
 
 // -------------------------- M0S MCU interface -----------------------
 // intn and dout are outputs driven by the FPGA to the MCU
@@ -634,7 +631,7 @@ wire [5:0] ide_config = { 5'b10000, osd_ide_enable };
 nanomig nanomig
 (
  .clk_sys(clk_28m),
- .reset(cpu_reset),
+ .reset(nanomig_reset),
  .por(rst_28m),
 
  .clk7_en(clk7_en),
@@ -940,15 +937,19 @@ reg signed [14:0] scaled_audio_right;
 // An integer divider cannot hit 48kHz: 28500000 / 48000 / 2 = 296.88, and the
 // truncation leaves the stream running fast, which makes sinks drop a chunk of
 // audio every few seconds. A phase accumulator keeps the fractional part.
-localparam [31:0] AUDIO_INC = (64'd48000 <<< 32) / `PIXEL_CLOCK;
-reg [31:0] aclk_acc;
-reg        clk_audio;
-reg        aclk_tick;
+localparam integer AUDIO_RATE = 48000;
+localparam integer AUDIO_ACC_WIDTH = $clog2(`PIXEL_CLOCK + AUDIO_RATE);
+
+localparam [AUDIO_ACC_WIDTH-1:0] AUDIO_INC = ((AUDIO_ACC_WIDTH*2)'(AUDIO_RATE) <<< AUDIO_ACC_WIDTH) / `PIXEL_CLOCK;
+
+reg [AUDIO_ACC_WIDTH-1:0] aclk_acc;
+reg                       clk_audio;
+reg                       aclk_tick;
 
 always @(posedge clk_pixel) begin
     aclk_acc  <= aclk_acc + AUDIO_INC;
-    clk_audio <= aclk_acc[31];                 // msb of the accumulator = 48kHz
-    aclk_tick <= (clk_audio != aclk_acc[31]);  // high the cycle after each edge
+    clk_audio <= aclk_acc[AUDIO_ACC_WIDTH-1];                 // msb of the accumulator = 48kHz
+    aclk_tick <= (clk_audio != aclk_acc[AUDIO_ACC_WIDTH-1]);  // high the cycle after each edge
 
     // The sample word must not change on the same clk_pixel edge that toggles
     // clk_audio: the hdmi module latches it on that very edge, so data and
@@ -1029,7 +1030,8 @@ video_analyzer video_analyzer (
 );
 
 hdmi #(
-    .AUDIO_RATE(48000), .AUDIO_BIT_WIDTH(16),
+    .AUDIO_RATE(AUDIO_RATE),
+    .AUDIO_BIT_WIDTH(16),
     .VENDOR_NAME( { "MiSTle", 16'd0} ),
     .PRODUCT_DESCRIPTION( {"Nanomig", 72'd0} )
 ) hdmi(


### PR DESCRIPTION
- Add cache for IcePi Zero and make it fit 25k
- Optimize sd_card.v to keep `direct_start` in LUTRAM instead of registers
- Limit image size to 1TiB (**I think it should be enough for Amiga**)
- Optimize audio counter width (25 bits are enough)
- Makes Tang Nano 20k build + placement work again