### PR TITLE
sim: finish the fastram_dout48 rename

### DIFF
--- a/sim/nanomig_tb.v
+++ b/sim/nanomig_tb.v
@@ -319,7 +319,7 @@ nanomig nanomig (
 		 .fastram_lds(fastram_lds),
 		 .fastram_uds(fastram_uds),
 		 .fastram_dout(fastram_dout),
-		 .fastram_dout48(fastram_chip48),
+		 .fastram_dout48(fastram_dout48),
 		 .fastram_din(fastram_din),
 		 .fastram_wr(fastram_wr),
 		 .fastram_ready(fastram_ready)


### PR DESCRIPTION
The `fastram_chip48` → `fastram_dout48` rename is incomplete: the `nanomig` instance still connects the old name, while the declaration and the sdram's `p2_dout48` use the new one. `fastram_chip48` is therefore undeclared and becomes an implicit single bit — verilator says so directly:

```
%Warning-IMPLICIT: nanomig_tb.v:322:20: Signal definition not found, creating implicitly: 'fastram_chip48'
%Warning-WIDTHEXPAND: nanomig_tb.v:322:5: Input port connection 'fastram_dout48' expects 48 bits on the pin connection, but pin connection's VARREF 'fastram_chip48' generates 1 bits.
```

That leaves the upper 48 bits of every cache line fill undriven, so the cpu reads garbage from the first instruction on.

Measured on the tang_nano20k_020 config, same harness both sides:

| | before | after |
|---|---|---|
| verdict | never leaves a black screen (161 frames) | boots to the insert disk screen at frame 171 |
| power led events | 1 | 2 |

Simulation only — `top_020.sv` wires `chip48` correctly, so no bitstream is affected.
