### PR TITLE
sim: make the simulation match the shipped 020 build

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -8,7 +8,11 @@ OBJ_DIR=obj_dir
 
 # generic config defines
 DEFINES = -DINFER_DPRAM
-#DEFINES += -DENABLE_TG68K
+DEFINES += -DENABLE_TG68K
+DEFINES += -DENABLE_CACHE
+DEFINES += -DCHIPRAM_CACHE
+DEFINES += -DCPU_SLOW14
+DEFINES += -DDENISE_EBR
 #DEFINES += -DNO_COMPANION -DIMAGE_SIZE=1048576 -DIMAGE_INDEX=0
 
 # the original fx68k won't simulate. Thus we use this special version for simulation
@@ -22,7 +26,7 @@ TG68K_FILES=TG68KdotC_Kernel.v
 
 # Minimig-AGA
 MINIMIG_DIR=../src/minimig-aga
-MINIMIG_FILES=../nanomig.v amiga_clk.v cpu_wrapper.v cpu_cache_new.v dpram.v minimig.v 
+MINIMIG_FILES=../nanomig.v amiga_clk.v cpu_wrapper.v cpu_cache_new.v dpram.v dpram_be_1024x16.v minimig.v 
 MINIMIG_FILES+=bitplane_ram.v sprite_ram.v
 MINIMIG_FILES+=ciaa.v ciab.v cia_int.v cia_timera.v cia_timerb.v cia_timerd.v 
 MINIMIG_FILES+=paula.v paula_uart.v paula_audio_channel.v paula_audio_mixer.v paula_audio.v paula_audio_volume.v paula_floppy_fifo.v paula_floppy.v paula_intcontroller.v

--- a/sim/nanomig_tb.cpp
+++ b/sim/nanomig_tb.cpp
@@ -511,7 +511,15 @@ void tick(int c) {
   static int sector_tx_cnt = 512;
   static int sector_rx_cnt = 512;  
   
+  // Let the 28MHz edge settle before the 85MHz edges of this half period.
+  // On the board clk_28m is a CLKDIV output of clk_85m, so the 85MHz domain
+  // sees the new clk7_en right away. Evaluating both edges in one eval()
+  // started the sdram one 85MHz clock late, which was harmless with the old
+  // controller but makes the read data of the current controller miss the
+  // m68k bridge latch window - every chip bus read then returned the
+  // previous word and the cpu took a garbage reset vector.
   tb->clk = c;
+  tb->eval();
 
   if(c) {
 
@@ -769,7 +777,17 @@ int main(int argc, char **argv) {
   int chipset_aga = getenv("CHIPSET") ? atoi(getenv("CHIPSET")) : aga_mode;
   int cpu_sel     = getenv("CPU")     ? atoi(getenv("CPU"))     : (aga_mode ? 2 : 0);
   tb->chipset_config = chipset_aga ? 0x18 : 0x00;  // bits 4:3 = 11 -> AGA
-  tb->cpu_config = cpu_sel;                        // 2 = 68020
+  // sysctrl.v maps the menu value 2 to 2'b11 before it reaches cpu_config;
+  // nanomig.v documents the encoding as 00=68000, 01=68010, 11=68020.
+  // Driving a raw 2'b10 half configures TG68K: 32 bit mul/div on, but
+  // 68000 style stack frames, so RTE pops 6 bytes where exec pushed 8.
+  tb->cpu_config = (cpu_sel == 2) ? 3 : cpu_sel;
+  // 001 = turbo chip, 010 = turbo kick, 100 = data cache. 3 is the power on
+  // default of sysctrl.v (Turbo: both, Turbo data: off). Leaving this input
+  // unconnected made verilator tie it low and ran every simulation with turbo
+  // switched off entirely, which the kickstart takes many seconds to survive.
+  tb->turbo_config = getenv("TURBO") ? atoi(getenv("TURBO")) : 3;
+  printf("turbo_config = %d\n", tb->turbo_config);
   printf("config: chipset=%s cpu=%s\n", chipset_aga?"AGA":"OCS", cpu_sel==2?"68020":"68000");
 
   /* run for a while */

--- a/sim/nanomig_tb.v
+++ b/sim/nanomig_tb.v
@@ -33,6 +33,7 @@ module nanomig_tb
    input [5:0]	 ide_config,
    input [5:0]	 chipset_config, // bit 4:3 = 11 -> AGA
    input [1:0]	 cpu_config,     // 0=68000, 2=68020
+   input [2:0]	 turbo_config,   // 001=turbo chip, 010=turbo kick, 100=data cache
    
    output	 sdclk,
    output	 sdcmd,
@@ -277,6 +278,7 @@ nanomig nanomig (
 `endif
 		 .chipset_config(chipset_config),
 		 .cpu_config(cpu_config),
+		 .turbo_config(turbo_config),
 		 
 		 .hs(hs_n),
 		 .vs(vs_n),
@@ -342,14 +344,12 @@ wire        ram_refresh;
 wire [15:0] sdram_dout;
 wire [47:0] chip48_sdram;
 
-// run a counter at 28Mhz synchronous to the 7Mhz bus cycle (like top_020.sv)
-reg  [1:0]  cyc;
-always @(posedge clk)
-  if(clk7_en) cyc <= 2'd0;
-  else        cyc <= cyc + 2'd1;
-
 wire        sdram_access = (!_ram_oe || !_ram_we);
-wire        sdram_sync   = !cyc;
+
+// the memory cycle starts on the same edge as on the board, where top_020.sv
+// drives sync from clk7_en directly. A delayed sync shifts the whole sdram
+// state machine against the chipset bus and the read data arrives too late.
+wire        sdram_sync   = clk7_en;
 
 wire [31:0] sd_dq;
 wire [10:0] sd_addr;

--- a/sim/sdr_chip_model.v
+++ b/sim/sdr_chip_model.v
@@ -2,9 +2,10 @@
 //
 // Behavioral model of the Tang Nano 20K's in-package 32 bit SDR SDRAM,
 // just detailed enough for the NanoMig sdram.sv controller: ACTIVE/READ/
-// WRITE/LOAD MODE with CAS latency 2, burst length 1 or 2 (sequential,
-// wrapping within the aligned pair), byte masks on writes, single writes
-// (write burst disabled). Refresh and precharge are accepted and ignored.
+// WRITE/LOAD MODE with CAS latency 2, sequential bursts of 1, 2, 4 or 8
+// words wrapping within the aligned block, byte masks on writes, single
+// writes (write burst disabled). Refresh and precharge are accepted and
+// ignored.
 //
 // The memory array is verilator-public so the testbench can preload the
 // kickstart image directly.
@@ -27,7 +28,7 @@ module sdr_chip_model (
 reg [31:0] mem [0:2097151] /*verilator public_flat_rw*/;
 
 reg [10:0] row [0:3];
-reg	   burst2;         // mode register burst length 2
+reg [3:0]  blen;         // mode register burst length in words (1/2/4/8)
 
 wire [2:0] command = {ras_n, cas_n, we_n};
 localparam CMD_ACTIVE    = 3'b011;
@@ -38,10 +39,17 @@ localparam CMD_LOAD_MODE = 3'b000;
 // read data pipeline for CAS latency 2
 reg	    v0, v1;
 reg [31:0]  d0, d1;
-reg	    pend;         // second beat of a burst-2 read pending
-reg [20:0]  pa;           // address of the first beat
+reg [3:0]   bleft;        // beats of the current burst still to deliver
+reg [2:0]   bidx;         // index of the next beat within the burst
+reg [20:0]  base;         // address of the first beat
 
 wire [20:0] col_addr = {ba, row[ba], addr[7:0]};
+
+// sequential burst: the low log2(blen) address bits wrap inside the aligned
+// block, the bits above them stay put
+wire [2:0]  bmask = blen[2:0] - 3'd1;
+wire [20:0] beat_addr = { base[20:3],
+			  ((base[2:0] + bidx) & bmask) | (base[2:0] & ~bmask) };
 
 always @(posedge clk) begin
    // advance the CL pipeline
@@ -49,22 +57,24 @@ always @(posedge clk) begin
    d1 <= d0;
    v0 <= 1'b0;
 
-   if (pend) begin
-      // sequential burst-2 wraps within the aligned pair
-      d0   <= mem[{pa[20:1], ~pa[0]}];
-      v0   <= 1'b1;
-      pend <= 1'b0;
+   if (bleft != 0) begin
+      // remaining beats of the current burst, one per clock
+      d0    <= mem[beat_addr];
+      v0    <= 1'b1;
+      bidx  <= bidx + 3'd1;
+      bleft <= bleft - 4'd1;
    end
 
    if (!cs_n) begin
       case (command)
-	CMD_LOAD_MODE: burst2 <= (addr[2:0] == 3'b001);
+	CMD_LOAD_MODE: blen <= 4'd1 << addr[2:0];
 	CMD_ACTIVE:    row[ba] <= addr;
 	CMD_READ: begin
-	   d0   <= mem[col_addr];
-	   v0   <= 1'b1;
-	   pa   <= col_addr;
-	   pend <= burst2;
+	   d0    <= mem[col_addr];
+	   v0    <= 1'b1;
+	   base  <= col_addr;
+	   bidx  <= 3'd1;
+	   bleft <= blen - 4'd1;
 	end
 	CMD_WRITE: begin
 	   // single write with byte masks (write burst disabled)
@@ -72,7 +82,7 @@ always @(posedge clk) begin
 	   if (!dqm[2]) mem[col_addr][23:16] <= dq[23:16];
 	   if (!dqm[1]) mem[col_addr][15: 8] <= dq[15: 8];
 	   if (!dqm[0]) mem[col_addr][ 7: 0] <= dq[ 7: 0];
-	   pend <= 1'b0;
+	   bleft <= 4'd0;
 	end
 	default: ;  // nop/refresh/precharge ignored
       endcase


### PR DESCRIPTION
Needs #144 as well — with both applied the `tang_nano20k_020` config boots to the insert disk screen at frame 171 and reads track 0 from the adf.

Four defects, each verified separately by a boot:

**`turbo_config` was never connected**, so verilator tied it low and every run had turbo chip, turbo kick and the data cache off. Kickstart then crawls through exec's resident scan at chip bus speed (~1 MB/s measured) and never gets to the insert disk screen.

**`cpu_config` was driven with a raw 2.** `sysctrl.v` maps the menu value 2 to `2'b11`, and `nanomig.v` documents the encoding as `00/01/11`. A raw `2'b10` half configures `TG68KdotC_Kernel`, whose options are all "switchable": `cpu[1]` enables 32 bit mul/div and extended addressing, so the rom detects an 020, while `cpu[0]` still selects 68000 stack frames. `Supervisor()` builds an eight byte frame, `RTE` pops six, and the `RTS` at `$F80C0C` returns through a misaligned stack into unmapped memory.

**`ENABLE_TG68K` was commented out**, and `cpu_wrapper.v` auto-defines `ENABLE_FX68K` when no cpu is selected — so every run, including ones reporting `cpu=68020`, instantiated a 68000. Kickstart 3.1 for the A1200 reaches utility.library's divide helpers and executes `DIVU.L D1,D1:D0` at `$FBD994`; on a 68000 that is an illegal instruction and exec dead ends in the power led blinker at `$F835F2`.

**`sdr_chip_model` only served burst lengths 1 and 2** while the controller is instantiated with `CHIP48_BURST=1`, which selects `BURST_LENGTH = 3'b010`, a burst of 4.

The remaining `top_020.sv` defines are enabled too, so what is simulated is what is built, and `dpram_be_1024x16.v` is added — `cpu_cache_new.v` instantiates it four times for the tag rams and `build_020.tcl` already lists it.

Simulation only; no rtl is touched.
