### PR TITLE
TG68K and FX68K timing updates

### DIFF
--- a/src/minimig-aga/cpu_wrapper.v
+++ b/src/minimig-aga/cpu_wrapper.v
@@ -653,7 +653,7 @@ wire chipreq = cpu_req & ~ramsel
 ;
 
 reg [15:0] chipdout_i;
-reg        c_as,c_rw,c_uds,c_lds;
+reg        c_as, c_rw, c_uds, c_lds;
 
 always @(posedge clk, negedge reset) begin
 	reg [1:0] stage;
@@ -667,37 +667,43 @@ always @(posedge clk, negedge reset) begin
 		c_uds <= 1;
 		c_lds <= 1;
 		chipready <= 0;
-		ready <= 0;
 	end else begin
-		if (ph2) begin
-			waitm <= chip_dtack;
-			if(~stage[0]) cpu_ipl <= chip_ipl;
-		end
 		chipready <= 0;
+		if (ph2) begin
+			case (stage)
+				0: cpu_ipl <= chip_ipl;
+				1: ;
+				2: begin
+					cpu_ipl <= chip_ipl;
+					waitm <= chip_dtack;
+				end
+				3: begin
+					c_as <= 1;
+					c_rw <= 1;
+					c_uds <= 1;
+					c_lds <= 1;
+					ready <= 0;
+					chipdout_i <= chip_dout;
+					if (!ready)
+						chipready <= 1;
+					else
+						stage <= 0;
+				end
+				default: ;
+			endcase
+		end
 		if (ph1) begin
-			chipready <= ready;
-			ready <= 0;
 			case (stage)
 				0: if (chipreq) begin
-						c_as <= 0;
-						c_rw <= wr;
-						c_uds <= uds_in;
-						c_lds <= lds_in;
-						stage <= 1;
-					end
+					c_as <= 0;
+					c_rw <= wr;
+					c_uds <= uds_in;
+					c_lds <= lds_in;
+					stage <= 1;
+				end
 				1: stage <= 2;
-				2: begin
-						chipdout_i <= chip_dout;
-						if (~waitm) begin
-							c_as <= 1;
-							c_rw <= 1;
-							c_uds <= 1;
-							c_lds <= 1;
-							ready <= 1;
-							stage <= 3;
-						end
-					end
-				3: stage <= 0;
+				2: if (~waitm) stage <= 3;
+				3: ready <= 1;
 			endcase
 		end
 	end

--- a/src/minimig-aga/cpu_wrapper.v
+++ b/src/minimig-aga/cpu_wrapper.v
@@ -364,38 +364,37 @@ wire        longword;
 reg [2:0]   cpu_ipl;
 reg         chipready;
 
-// tg68_armed keeps the cpu from being clocked before the reset has been
-// released for at least one cycle, otherwise the TG68K can hang on startup
-reg  tg68_armed;
-always @(posedge clk) tg68_armed <= reset;
-
 `ifdef CPU_SLOW14
 // Advance the TG68K at most every second clk cycle (14MHz effective on a
 // 28MHz clock, matching the 14MHz 68EC020 of a real A1200). This makes all
 // TG68K internal register-to-register paths true two-cycle paths which is
-// required for timing closure on slow devices. The single cycle ready
-// strobes of the bus interfaces are latched so no handshake is ever lost.
-// Instead of a fixed phase enable only a minimum gap of one idle cycle
-// after every advance is enforced, so memory handshakes are consumed at
-// the earliest opportunity and no average alignment latency is added.
-reg  gap;       // previous clk cycle advanced the cpu
-reg  readyhold;
-wire ready_now = chipready | ramready
-`ifdef FASTCHIP_DEPRECATED
-     | fastchip_ready
-`endif
-     ;
-wire clkena_slow = ~gap & ((~cpu_req & tg68_armed) | ready_now | readyhold);
-assign cpu_clkena = clkena_slow;
+// required for timing closure on slow devices. Since the memory cycle always
+// takes at least one cycle and has at least one wait state, it's enough to
+// slow down CPU during its internal cycle.
+reg cpu_internal_ack;
+
 always @(posedge clk) begin
-	gap <= clkena_slow;
-	if (clkena_slow)               readyhold <= 1'b0;
-	else if (ready_now & cpu_req)  readyhold <= 1'b1;
+	if (cpu_clkena || ~reset)
+		cpu_internal_ack <= 1'b0;
+	else if (~cpu_req)
+		cpu_internal_ack <= 1'b1;
 end
+assign cpu_clkena = cpu_internal_ack | chipready | ramready
+`ifdef FASTCHIP_DEPRECATED
+	| fastchip_ready
+`endif
+;
 `else
+// tg68_armed keeps the cpu from being clocked before the reset has been
+// released for at least one cycle, otherwise the TG68K can hang on startup
+reg tg68_armed;
+
+always @(posedge clk)
+	tg68_armed <= reset;
+
 assign cpu_clkena = (~cpu_req & tg68_armed) | chipready | ramready
 `ifdef FASTCHIP_DEPRECATED
-		    | fastchip_ready
+	| fastchip_ready
 `endif
 ;
 `endif

--- a/src/misc/sdram.sv
+++ b/src/misc/sdram.sv
@@ -51,7 +51,8 @@ module sdram #(
   parameter RAM_CLOCK_SPEED  = 85_000_000,
   parameter SYNC_CLOCK_SPEED =  7_080_000,
   parameter CHIP48_BURST = 0,
-  parameter SYNC_DELAY = 4
+  parameter SYNC_DELAY = 4,
+  parameter ACK_DELAY = 1
 ) (
   input  wire clk,
   input  wire reset_n,  // init signal after FPGA config to initialize RAM
@@ -80,7 +81,6 @@ module sdram #(
   input wire  [1:0] ds,    // upper/lower data strobe
   input wire        cs,    // chipset requests read/write
   input wire        we,    // chipset requests write
-  output reg        ack,
 
   // cpu interface
   input  wire [15:0] p2_din,   // data input from cpu
@@ -91,7 +91,7 @@ module sdram #(
   input  wire  [1:0] p2_ds,    // upper/lower data strobe
   input  wire        p2_cs,    // cpu requests read/wrie
   input  wire        p2_we,    // cpu requests write
-  output reg         p2_ack
+  output wire        p2_ack
 );
 
 localparam WIDTH32 = (DATA_WIDTH == 32);
@@ -264,6 +264,8 @@ wire [15:0] ram_dout;
 reg                 sd_dq;
 reg [RAS_WIDTH-1:0] sd_addr_cas;
 
+reg p2_ack_i;
+
 generate
   if (WIDTH32) begin
     assign ram_dout_lo = sd_data[15: 0];
@@ -343,7 +345,7 @@ always @(posedge clk) begin
         ram_we  <= p2_we;
         ram_din <= p2_din;
 
-        addr_0  <= p2_addr[0];
+        addr_0 <= p2_addr[0];
       end
 
       if (sync_i) begin
@@ -374,14 +376,12 @@ always @(posedge clk) begin
           sd_cmd <= ram_we ? CMD_WRITE : CMD_READ;
           if (ram_we) begin
             sd_dq <= 1;
-            ack   <= ~ack;
           end
         end
         PORT_2: begin
           sd_cmd <= ram_we ? CMD_WRITE : CMD_READ;
           if (ram_we) begin
-            sd_dq  <= 1;
-            p2_ack <= ~p2_ack;
+            sd_dq <= 1;
           end
         end
         PORT_REFRESH: begin
@@ -394,11 +394,9 @@ always @(posedge clk) begin
       case (sdram_port)
         PORT_1 : begin
           dout <= ram_dout;
-          if (!ram_we) ack <= ~ack;
         end
         PORT_2 : begin
           p2_dout <= ram_dout;
-          if (!ram_we) p2_ack <= ~p2_ack;
         end
         default: ;
       endcase
@@ -419,14 +417,20 @@ generate
         STATE_CAS: begin
           case (sdram_port)
             PORT_1: if (ram_we) sd_dqm <= (addr_0 ? {2'b11, ram_ds} : {ram_ds, 2'b11});
-            PORT_2: if (ram_we) sd_dqm <= (addr_0 ? {2'b11, ram_ds} : {ram_ds, 2'b11});
+            PORT_2: if (ram_we) begin
+              p2_ack_i <= ~p2_ack_i;
+              sd_dqm <= (addr_0 ? {2'b11, ram_ds} : {ram_ds, 2'b11});
+            end
             default: ;
           endcase
         end
         STATE_READ_0: begin
           case (sdram_port)
             PORT_1: dout48[47:32] <= ram_dout_lo;
-            PORT_2: p2_dout48[47:32] <= ram_dout_lo;
+            PORT_2: begin
+              if (!ram_we && !CHIP48_BURST) p2_ack_i <= ~p2_ack_i;
+              p2_dout48[47:32] <= ram_dout_lo;
+            end
             default: ;
           endcase
         end
@@ -456,6 +460,7 @@ generate
                 /* no-op */;
             end
             PORT_2: begin
+              if (!ram_we && CHIP48_BURST) p2_ack_i <= ~p2_ack_i;
               if (addr_0)
                 p2_dout48[15:0] <= {ram_dout_hi};
               else
@@ -476,7 +481,20 @@ generate
         STATE_CAS: begin
           case (sdram_port)
             PORT_1: if (ram_we) sd_dqm <= ram_ds;
-            PORT_2: if (ram_we) sd_dqm <= ram_ds;
+            PORT_2: if (ram_we) begin
+              p2_ack_i <= ~p2_ack_i;
+              sd_dqm <= ram_ds;
+            end
+            default: ;
+          endcase
+        end
+        STATE_READ_0: begin
+          case (sdram_port)
+            PORT_1: dout48[47:32] <= ram_dout;
+            PORT_2: begin
+              if (!ram_we && !CHIP48_BURST) p2_ack_i <= ~p2_ack_i;
+              p2_dout48[47:32] <= ram_dout;
+            end
             default: ;
           endcase
         end
@@ -497,13 +515,39 @@ generate
         STATE_READ_3: begin
           case (sdram_port)
             PORT_1: dout48[15: 0] <= ram_dout;
-            PORT_2: p2_dout48[15: 0] <= ram_dout;
+            PORT_2: begin
+              if (!ram_we && CHIP48_BURST) p2_ack_i <= ~p2_ack_i;
+              p2_dout48[15: 0] <= ram_dout;
+            end
             default: ;
           endcase
         end
         default: ;
       endcase
     end
+  end
+endgenerate
+
+generate
+  if (ACK_DELAY == 1) begin
+    reg p2_ack_d;
+
+    always @(posedge clk)
+      p2_ack_d <= p2_ack_i;
+
+    assign p2_ack = p2_ack_d;
+
+  end else if (ACK_DELAY > 1) begin
+    reg [ACK_DELAY-1:0] p2_ack_d;
+
+    always @(posedge clk) begin
+      p2_ack_d <= {p2_ack_d[ACK_DELAY-2:0], p2_ack_i};
+    end
+
+    assign p2_ack = p2_ack_d[ACK_DELAY-1];
+
+  end else begin
+    assign p2_ack = p2_ack_i;
   end
 endgenerate
 

--- a/src/misc/sdram.sv
+++ b/src/misc/sdram.sv
@@ -254,6 +254,8 @@ assign sd_cas = sd_cmd[1];
 assign sd_we  = sd_cmd[0];
 
 reg  [15:0] ram_din;
+reg         ram_we;
+reg   [1:0] ram_ds;
 
 wire [15:0] ram_dout_lo;
 wire [15:0] ram_dout_hi;
@@ -320,7 +322,12 @@ always @(posedge clk) begin
         sd_addr_cas[CAS_WIDTH-1:0] <= addr32[CAS_WIDTH-1:0];
         sd_addr_cas[10] <= 1'b1;  // precharge
 
-        sd_ba   <= addr32[RAS_WIDTH+CAS_WIDTH+1:RAS_WIDTH+CAS_WIDTH];
+        sd_ba <= addr32[RAS_WIDTH+CAS_WIDTH+1:RAS_WIDTH+CAS_WIDTH];
+
+        ram_ds  <= ds;
+        ram_we  <= we;
+        ram_din <= din;
+
         addr_0  <= addr[0];
 
       end else if (p2_cs) begin
@@ -330,7 +337,12 @@ always @(posedge clk) begin
         sd_addr_cas[CAS_WIDTH-1:0] <= p2_addr32[CAS_WIDTH-1:0];
         sd_addr_cas[10] <= 1'b1;  // precharge
 
-        sd_ba   <= p2_addr32[RAS_WIDTH+CAS_WIDTH+1:RAS_WIDTH+CAS_WIDTH];
+        sd_ba <= p2_addr32[RAS_WIDTH+CAS_WIDTH+1:RAS_WIDTH+CAS_WIDTH];
+
+        ram_ds  <= p2_ds;
+        ram_we  <= p2_we;
+        ram_din <= p2_din;
+
         addr_0  <= p2_addr[0];
       end
 
@@ -340,17 +352,17 @@ always @(posedge clk) begin
 
         if (cs && !refresh) begin
           sdram_port <= PORT_1;
-          sd_cmd <= CMD_ACTIVE;
+          sd_cmd     <= CMD_ACTIVE;
 
         end else if (refreshcnt == 0 || (cs && refresh)) begin
           sdram_port <= PORT_REFRESH;
-          sd_cmd <= CMD_AUTO_REFRESH;
+          sd_cmd     <= CMD_NOP;
 
           refreshcnt <= SYNC_CYCLES_PER_REFRESH[REFRESHCNT_MAX_WIDTH-1:0];
 
         end else if (p2_cs) begin
           sdram_port <= PORT_2;
-          sd_cmd <= CMD_ACTIVE;
+          sd_cmd     <= CMD_ACTIVE;
         end
       end
     end
@@ -359,20 +371,21 @@ always @(posedge clk) begin
 
       case (sdram_port)
         PORT_1: begin
-          sd_cmd <= we ? CMD_WRITE : CMD_READ;
-          ram_din <= din;
-          if (we) begin
+          sd_cmd <= ram_we ? CMD_WRITE : CMD_READ;
+          if (ram_we) begin
             sd_dq <= 1;
             ack   <= ~ack;
           end
         end
         PORT_2: begin
-          sd_cmd <= p2_we ? CMD_WRITE : CMD_READ;
-          ram_din <= p2_din;
-          if (p2_we) begin
+          sd_cmd <= ram_we ? CMD_WRITE : CMD_READ;
+          if (ram_we) begin
             sd_dq  <= 1;
             p2_ack <= ~p2_ack;
           end
+        end
+        PORT_REFRESH: begin
+          sd_cmd <= CMD_AUTO_REFRESH;
         end
         default: ;
       endcase
@@ -381,11 +394,11 @@ always @(posedge clk) begin
       case (sdram_port)
         PORT_1 : begin
           dout <= ram_dout;
-          if (!we) ack <= ~ack;
+          if (!ram_we) ack <= ~ack;
         end
         PORT_2 : begin
           p2_dout <= ram_dout;
-          if (!p2_we) p2_ack <= ~p2_ack;
+          if (!ram_we) p2_ack <= ~p2_ack;
         end
         default: ;
       endcase
@@ -405,8 +418,8 @@ generate
       case (state)
         STATE_CAS: begin
           case (sdram_port)
-            PORT_1: if (we)    sd_dqm <= (addr_0 ? {2'b11,    ds} : {ds,    2'b11});
-            PORT_2: if (p2_we) sd_dqm <= (addr_0 ? {2'b11, p2_ds} : {p2_ds, 2'b11});
+            PORT_1: if (ram_we) sd_dqm <= (addr_0 ? {2'b11, ram_ds} : {ram_ds, 2'b11});
+            PORT_2: if (ram_we) sd_dqm <= (addr_0 ? {2'b11, ram_ds} : {ram_ds, 2'b11});
             default: ;
           endcase
         end
@@ -462,8 +475,8 @@ generate
       case (state)
         STATE_CAS: begin
           case (sdram_port)
-            PORT_1: if (we)    sd_dqm <= ds;
-            PORT_2: if (p2_we) sd_dqm <= p2_ds;
+            PORT_1: if (ram_we) sd_dqm <= ram_ds;
+            PORT_2: if (ram_we) sd_dqm <= ram_ds;
             default: ;
           endcase
         end

--- a/src/mistle/gw3a_20/nanomig.sdc
+++ b/src/mistle/gw3a_20/nanomig.sdc
@@ -14,8 +14,8 @@ create_clock -name clk_audio -period 20833 -waveform {0 10416} [get_nets {clk_au
 // every multi cycle setup exception needs its hold counterpart, otherwise the
 // hold analysis still assumes a single cycle relationship between the two
 // domains and reports thousands of meaningless violations
-set_multicycle_path -from [get_clocks {clk28}] -to [get_clocks {clk85}] 4
-set_multicycle_path -from [get_clocks {clk28}] -to [get_clocks {clk85}] -hold 3
+set_multicycle_path -from [get_clocks {clk28}] -to [get_clocks {clk85}] 2
+set_multicycle_path -from [get_clocks {clk28}] -to [get_clocks {clk85}] -hold 1
 set_multicycle_path -from [get_clocks {clk85}] -to [get_clocks {clk28}] -start 2
 set_multicycle_path -from [get_clocks {clk85}] -to [get_clocks {clk28}] -hold -start 1
 
@@ -28,6 +28,15 @@ set_false_path -from [get_cells {sysctrl/system_fastmem*}]
 set_false_path -from [get_cells {sysctrl/system_turbo*}]
 set_false_path -from [get_cells {sysctrl/system_volume*}]
 
+// the TG68K advances at most every second clk28 cycle (CPU_SLOW14 in
+// cpu_wrapper.v), so all its internal register to register paths are
+// true two cycle paths
+set_multicycle_path -from [get_regs {*cpu_inst_p/*}] -to [get_regs {*cpu_inst_p/*}] -setup -end 2
+set_multicycle_path -from [get_regs {*cpu_inst_p/*}] -to [get_regs {*cpu_inst_p/*}] -hold -end 1
+// the TG68K register file is distributed LUT ram, not covered by get_regs,
+// so additionally relax paths ending at any pin inside the cpu core
+set_multicycle_path -from [get_regs {*cpu_inst_p/*}] -to [get_pins {*cpu_inst_p/*/DI* *cpu_inst_p/*/AD* *cpu_inst_p/*/WRE}] -setup -end 2
+set_multicycle_path -from [get_regs {*cpu_inst_p/*}] -to [get_pins {*cpu_inst_p/*/DI* *cpu_inst_p/*/AD* *cpu_inst_p/*/WRE}] -hold -end 1
 // The hdmi audio sample words cross from the 48kHz audio clock into the pixel
 // clock domain through a toggle handshake: the data is written a full audio
 // period (~10us) before the synchronized toggle releases the capture, so the

--- a/src/mistle/gw3a_20/top.sv
+++ b/src/mistle/gw3a_20/top.sv
@@ -7,7 +7,7 @@
 `define ENABLE_AGA
 `define ENABLE_RAM32
 `define ENABLE_TG68K  // required for AGA as that expects a 020 cpu
-// `define CPU_SLOW14    // run TG68K at 14MHz effective (A1200 speed) for timing closure
+`define CPU_SLOW14    // run TG68K at 14MHz effective (A1200 speed) for timing closure
 // `define DENISE_EBR    // block ram based bitplane and sprite buffers, saves logic
 `define ENABLE_CACHE  // required for AGA as the 020 has caches
 `define CHIPRAM_CACHE // cache chip ram instruction fetches too (a1200 68ec020 style) with chip bus snooping
@@ -703,10 +703,8 @@ localparam CHIP48_BURST = 0
 ;
 
 sdram #(
-`ifdef ENABLE_AGA
-    .CHIP48_BURST(CHIP48_BURST),  // required only for AGA
-`endif
-    .SYNC_DELAY(2)
+    .SYNC_DELAY(2),
+    .CHIP48_BURST(CHIP48_BURST)   // the wide 64 bit fetch AGA or cache needs
 ) sdram (
     .sd_data    ( IO_sdram_dq   ), // 14 bit bidirectional data bus
     .sd_addr    ( O_sdram_addr  ), // 13 bit multiplexed address bus
@@ -734,7 +732,6 @@ sdram #(
     .ds         ( sdram_be      ), // upper/lower data strobe
     .cs         ( sdram_cs      ), // cpu/chipset requests read/wrie
     .we         ( sdram_we      ), // cpu/chipset requests write
-	.ack        (               ),
 		 
     .p2_din     ( fastram_din   ), // data input from cpu
     .p2_dout    ( fastram_dout  ),

--- a/src/mistle/gw5a_25/nanomig.sdc
+++ b/src/mistle/gw5a_25/nanomig.sdc
@@ -14,8 +14,8 @@ create_clock -name clk_audio -period 20833 -waveform {0 10416} [get_nets {clk_au
 // every multi cycle setup exception needs its hold counterpart, otherwise the
 // hold analysis still assumes a single cycle relationship between the two
 // domains and reports thousands of meaningless violations
-set_multicycle_path -from [get_clocks {clk28}] -to [get_clocks {clk85}] 4
-set_multicycle_path -from [get_clocks {clk28}] -to [get_clocks {clk85}] -hold 3
+set_multicycle_path -from [get_clocks {clk28}] -to [get_clocks {clk85}] 2
+set_multicycle_path -from [get_clocks {clk28}] -to [get_clocks {clk85}] -hold 1
 set_multicycle_path -from [get_clocks {clk85}] -to [get_clocks {clk28}] -start 2
 set_multicycle_path -from [get_clocks {clk85}] -to [get_clocks {clk28}] -hold -start 1
 
@@ -28,6 +28,11 @@ set_false_path -from [get_cells {sysctrl/system_fastmem*}]
 set_false_path -from [get_cells {sysctrl/system_turbo*}]
 set_false_path -from [get_cells {sysctrl/system_volume*}]
 
+// the TG68K advances at most every second clk28 cycle (CPU_SLOW14 in
+// cpu_wrapper.v), so all its internal register to register paths are
+// true two cycle paths
+set_multicycle_path -from [get_regs {*cpu_inst_p/*}] -to [get_regs {*cpu_inst_p/*}] -setup -end 2
+set_multicycle_path -from [get_regs {*cpu_inst_p/*}] -to [get_regs {*cpu_inst_p/*}] -hold -end 1
 // The hdmi audio sample words cross from the 48kHz audio clock into the pixel
 // clock domain through a toggle handshake: the data is written a full audio
 // period (~10us) before the synchronized toggle releases the capture, so the

--- a/src/mistle/gw5a_25/top.sv
+++ b/src/mistle/gw5a_25/top.sv
@@ -7,11 +7,11 @@
 `define ENABLE_AGA
 `define ENABLE_RAM32
 `define ENABLE_TG68K  // required for AGA as that expects a 020 cpu
-// `define CPU_SLOW14    // run TG68K at 14MHz effective (A1200 speed) for timing closure
-// `define DENISE_EBR    // block ram based bitplane and sprite buffers, saves logic
+`define CPU_SLOW14    // run TG68K at 14MHz effective (A1200 speed) for timing closure
+//`define DENISE_EBR    // block ram based bitplane and sprite buffers, saves logic
 `define ENABLE_CACHE  // required for AGA as the 020 has caches
 `define CHIPRAM_CACHE // cache chip ram instruction fetches too (a1200 68ec020 style) with chip bus snooping
-// `define NO_WS2812     // drop the rgb status led to make room for cache + ide
+//`define NO_WS2812     // drop the rgb status led to make room for cache + ide
 `define ENABLE_RTC
 `define DISABLE_ROM_IMAGE
 
@@ -704,10 +704,8 @@ localparam CHIP48_BURST = 0
 ;
 
 sdram #(
-`ifdef ENABLE_AGA
-    .CHIP48_BURST(CHIP48_BURST),  // required only for AGA
-`endif
-    .SYNC_DELAY(2)
+    .SYNC_DELAY(2),
+    .CHIP48_BURST(CHIP48_BURST)   // the wide 64 bit fetch AGA or cache needs
 ) sdram (
     .sd_data    ( IO_sdram_dq   ), // 14 bit bidirectional data bus
     .sd_addr    ( O_sdram_addr  ), // 13 bit multiplexed address bus
@@ -735,7 +733,6 @@ sdram #(
     .ds         ( sdram_be      ), // upper/lower data strobe
     .cs         ( sdram_cs      ), // cpu/chipset requests read/wrie
     .we         ( sdram_we      ), // cpu/chipset requests write
-	.ack        (               ),
 		 
     .p2_din     ( fastram_din   ), // data input from cpu
     .p2_dout    ( fastram_dout  ),

--- a/src/nanomig.v
+++ b/src/nanomig.v
@@ -147,8 +147,8 @@ reg cpu_ph1, cpu_ph2, cpu_sync;
 //
 // signal   | cycle
 // -------------------
-// c1       | 1 1 0 0
-// c3       | 0 1 1 0
+// c1       | 0 1 1 0
+// c3       | 0 0 1 1
 // -------------------
 // clk7_en  | 1 0 0 0
 // clk7n_en | 0 0 1 0
@@ -173,8 +173,8 @@ always @(*) begin
       cpu_ph1 = 1'b0;
       cpu_ph2 = 1'b0;
    end else begin
-      cpu_ph1 = !c1 && !c3 && cpu_sync;
-      cpu_ph2 =  c1 &&  c3 && cpu_sync;
+      cpu_ph1 = !c1 &&  c3 && cpu_sync;
+      cpu_ph2 =  c1 && !c3 && cpu_sync;
    end
 end
 

--- a/src/nanomig.v
+++ b/src/nanomig.v
@@ -215,7 +215,7 @@ always @(negedge clk_sys)
 `else
 assign pwr_led = pwr_led_bright;
 `endif
-   
+
 // -------------- fast(er) ram interface used in turbo mode --------------
 
 // This implements a direct path for the CPU to access ram. This can be used
@@ -223,32 +223,31 @@ assign pwr_led = pwr_led_bright;
 // faster access than usual. With the tg68k this can be used to speed up
 // the system significantly. Since Kickstart is also stored in ram, this also
 // speeds up kickstart rom access.
-   
+
 wire [15:0] ram_dout;
-wire [28:1] ram_addr;   
-wire	    ram_sel;
-wire	    ram_lds;
-wire	    ram_uds;
-   
+wire [28:1] ram_addr;
+wire        ram_sel;
+wire        ram_lds;
+wire        ram_uds;
+
 // ram_ready finally is the clkena for the tg68k
 `ifdef ENABLE_CACHE
 // ram_ready follows the cache acknowledge level directly instead of being
 // re-registered: cache_cs drops in the same cycle (see cache_cs below), which
 // makes the cache clear its ack, so this stays a single cycle pulse but
 // arrives one clock earlier - on every single cpu memory access.
-reg         ram_write_ready;   // write accepted into the write buffer
-wire        ram_ready = cache_ack | ram_write_ready;
+reg  ram_write_ready;   // write accepted into the write buffer
+wire ram_ready = cache_ack | ram_write_ready;
 `else
 // cpu_ph1 is just before clk7_en, so this is
 // the very last moment we can receive ACK from SDRAM;
 // if it didn't happen then it means our request
 // didn't go through and we need to retry in the next cycle
+reg fastram_ready_d;
 wire ram_ready = cpu_ph1 && (fastram_ready != fastram_ready_d);
 `endif
 
 `ifndef ENABLE_CACHE
-reg fastram_ready_d;
-
 // avoid selecting fastram when we didn't handle
 // ready signal yet (shouldn't happen but just
 // in case, it's better to keep it)
@@ -279,7 +278,7 @@ cpu_wrapper cpu_wrapper
 	.chip_dtack   (chip_dtack      ),
 	.chip_ipl     (chip_ipl        ),
 
- `ifdef FASTCHIP_DEPRECATED
+`ifdef FASTCHIP_DEPRECATED
 	.fastchip_dout   (  ),
 	.fastchip_sel    (  ),
 	.fastchip_lds    (  ),
@@ -289,7 +288,7 @@ cpu_wrapper cpu_wrapper
 	.fastchip_ready  ( 1'b0 ),
 	.fastchip_lw     (  ),
 `endif
- 
+
 	.cpucfg       (cpucfg          ),
 	.turbocfg     (turbocfg        ),
 	.fastramcfg   (fastram_config  ),
@@ -312,7 +311,7 @@ cpu_wrapper cpu_wrapper
 	.cacr         (cpu_cacr        ),
 	.nmi_addr     (cpu_nmi_addr    )
 );
-   
+
 `ifdef ENABLE_CACHE
 // ----------------------- cpu cache (MiSTer cpu_cache_new) -----------------------
 // The cache sits between the cpu's direct ram path and the sdram. Reads are
@@ -408,7 +407,7 @@ reg  [15:0] cache_fill_dat;
 
 `ifdef ENABLE_RAM32
 // We need to extend address width for devices with more than
-// 8MiB SDRAM to make 8MiB FastRAM work properly
+// 8MiB SDRAM to make 8MiB FastRAM work properly.
 localparam CACHE_ADDR_WIDTH = 24;
 `else
 localparam CACHE_ADDR_WIDTH = 23;
@@ -451,7 +450,6 @@ reg         wb_req;         // latched pending cache write
 reg         wb_en_d;        // wb_en edge detect
 reg         wr_lock;        // ack delivered, waiting for the cpu to consume it    // current cpu write has been acknowledged
 reg         cache_ack_d;
-reg         fastram_done_d;
 reg         fastram_sel_r;
 reg         fastram_wr_r;
 reg  [CACHE_ADDR_WIDTH-1:1] fastram_addr_r;
@@ -464,9 +462,10 @@ wire [1:0]  fill_word = fill_idx + fill_cnt;
 
 always @(posedge clk_sys) begin
   fastram_ready_d <= fastram_ready;
+  cache_ack_d     <= cache_ack;
+
   cache_fill_ack  <= 1'b0;
   ram_write_ready <= 1'b0;
-  cache_ack_d     <= cache_ack;
 
   if(!cpu_rst) begin
     fill_state    <= 2'd0;
@@ -478,10 +477,7 @@ always @(posedge clk_sys) begin
     fastram_sel_r <= 1'b0;
     fastram_wr_r  <= 1'b0;
   end else begin
-    // sdram port transaction finished. The read data is sampled one cycle
-    // after the ack has been seen to give the clock domain crossing from
-    // the 85MHz sdram controller a full cycle of settling time.
-    fastram_done_d <= fastram_done;
+    // sdram port transaction finished.
     if(fastram_done) begin
       fastram_sel_r <= 1'b0;
       wbuf_pending  <= 1'b0;
@@ -561,9 +557,9 @@ assign ram_dout     = cache_dat_r;
 assign fastram_addr = ram_addr[23:1];
 assign fastram_lds  = ram_lds;
 assign fastram_uds  = ram_uds;
-assign ram_dout     = fastram_dout;
 assign fastram_din  = ram_din;
 assign fastram_wr   = (cpu_state[1:0]==2'b11) ? 1'b1 : 1'b0;
+assign ram_dout     = fastram_dout;
 `endif
 
 wire [7:0] sdc_byte_out_data_fdc;   

--- a/src/nanomig.v
+++ b/src/nanomig.v
@@ -486,7 +486,7 @@ always @(posedge clk_sys) begin
       fastram_sel_r <= 1'b0;
       wbuf_pending  <= 1'b0;
     end
-    if(fastram_done_d && (fill_state == 2'd1)) begin
+    if(fastram_done && (fill_state == 2'd1)) begin
       fill_line  <= { fastram_dout, fastram_dout48 };
       fill_cnt   <= 2'd0;
       fill_state <= 2'd2;


### PR DESCRIPTION
This makes FX68K chip ram speed equal to 1x A500 speed; also fixes bus timing for TG68K and makes it follow the logic in MiST.

I'd appreciate testing on real HW with all variants (TN20K, TN20K 020, IcePi 020) and recording chip ram speed without any turbo enabled